### PR TITLE
Fix: UpdateSuppressionCrashFix in instantScheduling situations

### DIFF
--- a/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
+++ b/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
@@ -4,4 +4,11 @@ public class ThrowableSuppression extends RuntimeException{
     public ThrowableSuppression(String message) {
         super(message);
     }
+
+    /**
+     * {@code message = "Update Suppression"} by default
+     */
+    public ThrowableSuppression(){
+        this("Update Suppression");
+    }
 }

--- a/patches/net/minecraft/block/BlockFrostedIce.java.patch
+++ b/patches/net/minecraft/block/BlockFrostedIce.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockFrostedIce.java
++++ ../src-work/minecraft/net/minecraft/block/BlockFrostedIce.java
+@@ -1,6 +1,9 @@
+ package net.minecraft.block;
+ 
+ import java.util.Random;
++
++import carpet.CarpetSettings;
++import carpet.helpers.ThrowableSuppression;
+ import net.minecraft.block.properties.IProperty;
+ import net.minecraft.block.properties.PropertyInteger;
+ import net.minecraft.block.state.BlockStateContainer;
+@@ -38,6 +41,16 @@
+         }
+         else
+         {
++            // CM start
++            //noinspection SuspiciousIndentAfterControlStatement
++            if (CarpetSettings.updateSuppressionCrashFix) {
++                try {
++                    p_180650_1_.func_175684_a(p_180650_2_, this, MathHelper.func_76136_a(p_180650_4_, 20, 40));
++                } catch (StackOverflowError suppression) {
++                    throw new ThrowableSuppression();
++                }
++            } else
++            // CM end
+             p_180650_1_.func_175684_a(p_180650_2_, this, MathHelper.func_76136_a(p_180650_4_, 20, 40));
+         }
+     }

--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -1,14 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/entity/Entity.java
 +++ ../src-work/minecraft/net/minecraft/entity/Entity.java
-@@ -1,5 +1,7 @@
+@@ -1,5 +1,8 @@
  package net.minecraft.entity;
  
 +import carpet.carpetclient.CarpetClientChunkLogger;
++import carpet.helpers.ThrowableSuppression;
 +import carpet.patches.EntityPlayerMPFake;
  import com.google.common.collect.Iterables;
  import com.google.common.collect.Lists;
  import com.google.common.collect.Sets;
-@@ -81,6 +83,10 @@
+@@ -81,6 +84,10 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -19,7 +20,7 @@
  public abstract class Entity implements ICommandSender
  {
      private static final Logger field_184243_a = LogManager.getLogger();
-@@ -136,7 +142,7 @@
+@@ -136,7 +143,7 @@
      private int field_190534_ay;
      protected boolean field_70171_ac;
      public int field_70172_ad;
@@ -28,7 +29,7 @@
      protected boolean field_70178_ae;
      protected EntityDataManager field_70180_af;
      protected static final DataParameter<Byte> field_184240_ax = EntityDataManager.<Byte>func_187226_a(Entity.class, DataSerializers.field_187191_a);
-@@ -168,6 +174,9 @@
+@@ -168,6 +175,9 @@
      private final double[] field_191505_aI;
      private long field_191506_aJ;
  
@@ -38,7 +39,7 @@
      public Entity(World p_i1582_1_)
      {
          this.field_145783_c = field_70152_a++;
-@@ -278,6 +287,14 @@
+@@ -278,6 +288,14 @@
      {
          if (p_70105_1_ != this.field_70130_N || p_70105_2_ != this.field_70131_O)
          {
@@ -53,7 +54,7 @@
              float f = this.field_70130_N;
              this.field_70130_N = p_70105_1_;
              this.field_70131_O = p_70105_2_;
-@@ -299,7 +316,8 @@
+@@ -299,7 +317,8 @@
          }
      }
  
@@ -63,7 +64,7 @@
      {
          this.field_70177_z = p_70101_1_ % 360.0F;
          this.field_70125_A = p_70101_2_ % 360.0F;
-@@ -508,6 +526,12 @@
+@@ -508,6 +527,12 @@
  
      public void func_70091_d(MoverType p_70091_1_, double p_70091_2_, double p_70091_4_, double p_70091_6_)
      {
@@ -76,7 +77,7 @@
          if (this.field_70145_X)
          {
              this.func_174826_a(this.func_174813_aQ().func_72317_d(p_70091_2_, p_70091_4_, p_70091_6_));
-@@ -654,12 +678,28 @@
+@@ -654,12 +679,28 @@
                  }
              }
  
@@ -106,7 +107,7 @@
  
                  for (int l = list1.size(); k < l; ++k)
                  {
-@@ -672,6 +712,9 @@
+@@ -672,6 +713,9 @@
              if (p_70091_2_ != 0.0D)
              {
                  int j5 = 0;
@@ -116,7 +117,7 @@
  
                  for (int l5 = list1.size(); j5 < l5; ++j5)
                  {
-@@ -687,6 +730,9 @@
+@@ -687,6 +731,9 @@
              if (p_70091_6_ != 0.0D)
              {
                  int k5 = 0;
@@ -126,7 +127,18 @@
  
                  for (int i6 = list1.size(); k5 < i6; ++k5)
                  {
-@@ -1140,6 +1186,8 @@
+@@ -958,6 +1005,10 @@
+ 
+     protected void func_145775_I()
+     {
++        if (CarpetSettings.updateSuppressionCrashFix) {
++            doBlockCollisionsFixed();
++            return;
++        }
+         AxisAlignedBB axisalignedbb = this.func_174813_aQ();
+         BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185345_c(axisalignedbb.field_72340_a + 0.001D, axisalignedbb.field_72338_b + 0.001D, axisalignedbb.field_72339_c + 0.001D);
+         BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos1 = BlockPos.PooledMutableBlockPos.func_185345_c(axisalignedbb.field_72336_d - 0.001D, axisalignedbb.field_72337_e - 0.001D, axisalignedbb.field_72334_f - 0.001D);
+@@ -1140,6 +1191,8 @@
  
      public boolean func_70072_I()
      {
@@ -135,7 +147,7 @@
          if (this.func_184187_bx() instanceof EntityBoat)
          {
              this.field_70171_ac = false;
-@@ -1159,6 +1207,7 @@
+@@ -1159,6 +1212,7 @@
          {
              this.field_70171_ac = false;
          }
@@ -143,7 +155,7 @@
  
          return this.field_70171_ac;
      }
-@@ -1533,6 +1582,9 @@
+@@ -1533,6 +1587,9 @@
  
          if (!this.field_70128_L && s != null && !this.func_184218_aH())
          {
@@ -153,7 +165,7 @@
              p_70039_1_.func_74778_a("id", s);
              this.func_189511_e(p_70039_1_);
              return true;
-@@ -1543,6 +1595,19 @@
+@@ -1543,6 +1600,19 @@
          }
      }
  
@@ -173,7 +185,7 @@
      public static void func_190533_a(DataFixer p_190533_0_)
      {
          p_190533_0_.func_188258_a(FixTypes.ENTITY, new IDataWalker()
-@@ -1619,6 +1684,11 @@
+@@ -1619,6 +1689,11 @@
                  p_189511_1_.func_74782_a("Tags", nbttaglist);
              }
  
@@ -185,7 +197,7 @@
              this.func_70014_b(p_189511_1_);
  
              if (this.func_184207_aI())
-@@ -1663,19 +1733,19 @@
+@@ -1663,19 +1738,19 @@
              this.field_70181_x = nbttaglist2.func_150309_d(1);
              this.field_70179_y = nbttaglist2.func_150309_d(2);
  
@@ -216,7 +228,7 @@
              }
  
              this.field_70165_t = nbttaglist.func_150309_d(0);
-@@ -1744,6 +1814,17 @@
+@@ -1744,6 +1819,17 @@
              {
                  this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
              }
@@ -234,7 +246,7 @@
          }
          catch (Throwable throwable)
          {
-@@ -1908,7 +1989,12 @@
+@@ -1908,7 +1994,12 @@
  
      public double func_70042_X()
      {
@@ -247,7 +259,7 @@
      }
  
      public boolean func_184220_m(Entity p_184220_1_)
-@@ -1966,6 +2052,18 @@
+@@ -1966,6 +2057,18 @@
          }
      }
  
@@ -266,7 +278,7 @@
      protected void func_184200_o(Entity p_184200_1_)
      {
          if (p_184200_1_.func_184187_bx() != this)
-@@ -2398,7 +2496,10 @@
+@@ -2398,7 +2501,10 @@
                  float f = this.field_70177_z;
                  this.func_70012_b(d0, this.field_70163_u, d1, 90.0F, 0.0F);
                  Teleporter teleporter = worldserver1.func_85176_s();
@@ -277,7 +289,7 @@
                  blockpos = new BlockPos(this);
              }
  
-@@ -2578,6 +2679,10 @@
+@@ -2578,6 +2684,10 @@
  
      public EnumFacing func_174811_aO()
      {
@@ -288,7 +300,7 @@
          return EnumFacing.func_176731_b(MathHelper.func_76128_c((double)(this.field_70177_z * 4.0F / 360.0F) + 0.5D) & 3);
      }
  
-@@ -2886,4 +2991,14 @@
+@@ -2886,4 +2996,46 @@
      {
          return 1;
      }
@@ -301,5 +313,37 @@
 +    
 +    public void postLoad()
 +    {
++    }
++
++    // Update Suppression crash fixes - ITT fix - Naftalluvia
++    protected void doBlockCollisionsFixed() {
++        AxisAlignedBB box = this.func_174813_aQ();
++        BlockPos.PooledMutableBlockPos posMin = BlockPos.PooledMutableBlockPos.func_185345_c(box.field_72340_a + 0.001D, box.field_72338_b + 0.001D, box.field_72339_c + 0.001D);
++        BlockPos.PooledMutableBlockPos posMax = BlockPos.PooledMutableBlockPos.func_185345_c(box.field_72336_d - 0.001D, box.field_72337_e - 0.001D, box.field_72334_f - 0.001D);
++        BlockPos.PooledMutableBlockPos posIter = BlockPos.PooledMutableBlockPos.func_185346_s();
++        if (this.field_70170_p.func_175707_a(posMin, posMax)) {
++            for (int i = posMin.func_177958_n(); i <= posMax.func_177958_n(); ++i) {
++                for (int j = posMin.func_177956_o(); j <= posMax.func_177956_o(); ++j) {
++                    for (int k = posMin.func_177952_p(); k <= posMax.func_177952_p(); ++k) {
++                        posIter.func_181079_c(i, j, k);
++                        IBlockState iblockstate = this.field_70170_p.func_180495_p(posIter);
++                        try {
++                            iblockstate.func_177230_c().func_180634_a(this.field_70170_p, posIter, iblockstate, this);
++                            this.func_191955_a(iblockstate);
++                        } catch (StackOverflowError | ThrowableSuppression suppression) {
++                            throw new ThrowableSuppression();
++                        } catch (Throwable throwable) {
++                            CrashReport crashreport = CrashReport.func_85055_a(throwable, "Colliding entity with block");
++                            CrashReportCategory crashreportcategory = crashreport.func_85058_a("Block being collided with");
++                            CrashReportCategory.func_175750_a(crashreportcategory, posIter, iblockstate);
++                            throw new ReportedException(crashreport);
++                        }
++                    }
++                }
++            }
++        }
++        posMin.func_185344_t();
++        posMax.func_185344_t();
++        posIter.func_185344_t();
 +    }
  }

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -648,7 +648,7 @@
      }
  
      public DifficultyInstance func_175649_E(BlockPos p_175649_1_)
-@@ -3361,4 +3603,120 @@
+@@ -3361,4 +3603,116 @@
      {
          return null;
      }
@@ -671,11 +671,7 @@
 +                WorldHelper.onBlockUpdate(this, pos, iblockstate); // RSMM
 +                iblockstate.func_189546_a(this, pos, blockIn, fromPos);
 +            }
-+            catch (ThrowableSuppression e)
-+            {
-+                throw new ThrowableSuppression("Update Suppression");
-+            }
-+            catch (StackOverflowError e)
++            catch (ThrowableSuppression | StackOverflowError e)
 +            {
 +                throw new ThrowableSuppression("Update Suppression");
 +            }


### PR DESCRIPTION
Fix the bug that `updateSuppressionCrashFix` did not work with some instantTileTick self-loops
(Pressure Plates, Detector Rail, Tripwire, and Frosted Ice),
by throwing `ThrowableSuppression` in `Entity::doBlockCollisions` and `BlockFrostedIce::updateTick`.