### PR TITLE
Better profiler and TPS logger

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,19 +13,19 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 
 # Feature Modifications
 
-- Improved help info of command `/spawn`.
-- More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
-- Fixed a bug causing crashes when `/log` is executed while an invalid null option subscribes players.
-- Calculate the actual TPS when a single tick runs for more than 20 ms (by `1000/avg(max(50,millis))`). Thus, `TPS` and `MSPT` imply the different information.
-- More options of MSPT | TPS logger:
-    - `average`: (Default) The average within 100 gt, similar to the old logger.
-    - `sample`: The average within `HUDUpdateInterval`.
-    - `peak`: The worst tick time within `HUDUpdateInterval`.
-- Modifications of carpet profiling terms:
-    - Add `carpet`: The carpet server ticking.
-    - Add `<dim>`: Total tick time of each dimension.
-    - Add `<dim>.tile_ticks`, `<dim>.chunk_ticks`, `<dim>.block_events`, `<dim>.rest`.
-    - Remove `<dim>.blocks`.
+1. Improved help info of command `/spawn`.
+2. More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
+3. Fixed a bug causing crashes when `/log` is executed while an invalid null option subscribes players.
+4. Calculate the actual TPS when a single tick runs for more than 20 ms (by `1000/avg(max(50,millis))`). Thus, `TPS` and `MSPT` imply the different information.
+5. More options of MSPT | TPS logger:
+    1. `average`: (Default) The average within 100 gt, similar to the old logger.
+    2. `sample`: The average within `HUDUpdateInterval`.
+    3. `peak`: `MSPT` for the worst tick time, `TPS` for the average, both within `HUDUpdateInterval`.
+6. Modifications of carpet profiling terms:
+    1. Add `carpet`: The carpet server ticking.
+    2. Add `<dim>`: Total tick time of each dimension.
+    3. Add `<dim>.tile_ticks`, `<dim>.chunk_ticks`, `<dim>.block_events`, `<dim>.rest`.
+    4. Remove `<dim>.blocks`.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,12 +11,13 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 - Define and throw `ChunkNotGeneratedException`.
 - Make command `/perimeterinfo` check multiple entities.
 - Add modes of MSPT logger: `peak`, `average`, `sample`.
-- Calculate the actual TPS when a single tick runs for more than 20 ms (`1 / max(50, ms)`).
 
 # Feature Modifications
 
 - Improved help info of command `/spawn`.
 - More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
+- Fixed a bug causing crashes when `/log` is executed while an invalid null option subscribes players.
+- Calculate the actual TPS when a single tick runs for more than 20 ms (by `1000/avg(max(50,millis))`). Thus, `TPS` and `MSPT` imply the different information.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,8 +22,10 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
     - `sample`: The average within `HUDUpdateInterval`.
     - `peak`: The worst tick time within `HUDUpdateInterval`.
 - Modifications of carpet profiling terms:
-    - `carpet`: The carpet server ticking.
-    - `<dim>`: Total tick time of each dimension.
+    - Add `carpet`: The carpet server ticking.
+    - Add `<dim>`: Total tick time of each dimension.
+    - Add `<dim>.tile_ticks`, `<dim>.chunk_ticks`, `<dim>.block_events`, `<dim>.rest`.
+    - Remove `<dim>.blocks`.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,9 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
     - `average`: (Default) The average within 100 gt, similar to the old logger.
     - `sample`: The average within `HUDUpdateInterval`.
     - `peak`: The worst tick time within `HUDUpdateInterval`.
+- Modifications of carpet profiling terms:
+    - `carpet`: The carpet server ticking.
+    - `<dim>`: Total tick time of each dimension.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,8 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 
 # Feature Modifications
 
-- Improve help info of command `/spawn`.
+- Improved help info of command `/spawn`.
+- More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 - Add a spawning rate calculator.
 - Define and throw `ChunkNotGeneratedException`.
 - Make command `/perimeterinfo` check multiple entities.
+- Add modes of MSPT logger: `peak`, `average`, `moment`.
+- Calculate the actual TPS when a single tick runs for more than 20 ms (`1 / max(50, ms)`).
 
 # Feature Modifications
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,6 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 - Add a spawning rate calculator.
 - Define and throw `ChunkNotGeneratedException`.
 - Make command `/perimeterinfo` check multiple entities.
-- Add modes of MSPT logger: `peak`, `average`, `sample`.
 
 # Feature Modifications
 
@@ -18,6 +17,10 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 - More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
 - Fixed a bug causing crashes when `/log` is executed while an invalid null option subscribes players.
 - Calculate the actual TPS when a single tick runs for more than 20 ms (by `1000/avg(max(50,millis))`). Thus, `TPS` and `MSPT` imply the different information.
+- More options of MSPT | TPS logger:
+    - `average`: (Default) The average within 100 gt, similar to the old logger.
+    - `sample`: The average within `HUDUpdateInterval`.
+    - `peak`: The worst tick time within `HUDUpdateInterval`.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 - Add a spawning rate calculator.
 - Define and throw `ChunkNotGeneratedException`.
 - Make command `/perimeterinfo` check multiple entities.
-- Add modes of MSPT logger: `peak`, `average`, `moment`.
+- Add modes of MSPT logger: `peak`, `average`, `sample`.
 - Calculate the actual TPS when a single tick runs for more than 20 ms (`1 / max(50, ms)`).
 
 # Feature Modifications

--- a/carpetmodSrc/carpet/CarpetServer.java
+++ b/carpetmodSrc/carpet/CarpetServer.java
@@ -123,6 +123,7 @@ public class CarpetServer // static for now - easier to handle all around the co
     }
 
     public static void tick(MinecraftServer server) {
+        CarpetProfiler.start_section(null, "carpet");
         TickSpeed.tick(server);
         if (CarpetSettings.redstoneMultimeterLegacy) {
             TickStartEventDispatcher.dispatchEvent(server.getTickCounter());
@@ -133,6 +134,7 @@ public class CarpetServer // static for now - easier to handle all around the co
         HUDController.update_hud(server);
         WorldEditBridge.onStartTick();
         PUBSUB.update(server.getTickCounter());
+        CarpetProfiler.end_current_section();
     }
 
     public static void playerConnected(EntityPlayerMP player) {

--- a/carpetmodSrc/carpet/commands/CommandLog.java
+++ b/carpetmodSrc/carpet/commands/CommandLog.java
@@ -299,7 +299,7 @@ public class CommandLog extends CommandCarpetBase {
                 }
             } else {
                 for (String option : logger.getOptions()) {
-                    if (subs.containsKey(lname) && subs.get(lname).option.equalsIgnoreCase(option)) {
+                    if (subs.containsKey(lname) && option.equalsIgnoreCase(subs.get(lname).option)) {
                         comp.add("l [" + option + "] ");
                     } else {
                         comp.add(color + " [" + option + "] ");
@@ -343,7 +343,7 @@ public class CommandLog extends CommandCarpetBase {
                 }
             } else {
                 for (String option : logger.getOptions()) {
-                    if (subs.containsKey(lname) && subs.get(lname).option.equalsIgnoreCase(option)) {
+                    if (subs.containsKey(lname) && option.equalsIgnoreCase(subs.get(lname).option)) {
                         comp.add("l [" + option + "] ");
                     } else {
                         comp.add(color + " [" + option + "] ");

--- a/carpetmodSrc/carpet/commands/CommandProfile.java
+++ b/carpetmodSrc/carpet/commands/CommandProfile.java
@@ -1,55 +1,73 @@
 package carpet.commands;
 
-import javax.annotation.Nullable;
-
 import carpet.CarpetSettings;
 import carpet.utils.CarpetProfiler;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
 import java.util.List;
 
-public class CommandProfile extends CommandCarpetBase
-{
+public class CommandProfile extends CommandCarpetBase {
     @Override
-    public String getName()
-    {
+    @Nonnull
+    public String getName() {
         return "profile";
     }
 
     @Override
-    public String getUsage(ICommandSender sender)
-    {
-        return "Usage: /profile <entities>";
+    @Nonnull
+    @ParametersAreNonnullByDefault
+    public String getUsage(ICommandSender sender) {
+        return "/profile (entities | health) <ticks>";
     }
 
     @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
-    {
-        if (!command_enabled("commandProfile", sender)) return;
-        if (args.length > 0 && "entities".equalsIgnoreCase(args[0]))
-        {
-            CarpetProfiler.prepare_entity_report(100);
+    @ParametersAreNonnullByDefault
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if (!command_enabled("commandProfile", sender)) {
+            return;
         }
-        else
-        {
+        if (args.length > 0) {
+            if ("health".equalsIgnoreCase(args[0])) {
+                int step = 100;
+                if (args.length > 1) {
+                    step = parseInt(args[1], 20, 72000);
+                }
+                CarpetProfiler.prepare_tick_report(step);
+                return;
+            } else if ("entities".equalsIgnoreCase(args[0])) {
+                int step = 100;
+                if (args.length > 1) {
+                    step = parseInt(args[1], 20, 72000);
+                }
+                CarpetProfiler.prepare_entity_report(step);
+                return;
+            }
+        } else {
             CarpetProfiler.prepare_tick_report(100);
+            return;
         }
-
+        throw new WrongUsageException(getUsage(sender));
     }
-    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos)
-    {
-        if (!CarpetSettings.commandProfile)
-        {
-            return Collections.<String>emptyList();
+
+    @Nonnull
+    @ParametersAreNonnullByDefault
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos) {
+        if (!CarpetSettings.commandProfile) {
+            return Collections.emptyList();
         }
-        if (args.length == 1)
-        {
-            return getListOfStringsMatchingLastWord(args, "entities");
+        if (args.length == 1) {
+            return getListOfStringsMatchingLastWord(args, "entities", "health");
+        } else if (args.length == 2) {
+            return getListOfStringsMatchingLastWord(args, "20", "100", "900", "72000");
         }
-        return Collections.<String>emptyList();
+        return Collections.emptyList();
     }
 }

--- a/carpetmodSrc/carpet/commands/CommandTick.java
+++ b/carpetmodSrc/carpet/commands/CommandTick.java
@@ -4,6 +4,7 @@ import carpet.CarpetSettings;
 import carpet.carpetclient.CarpetClientMessageHandler;
 import carpet.helpers.TickSpeed;
 import carpet.utils.CarpetProfiler;
+import carpet.utils.Messenger;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.NumberInvalidException;
@@ -48,7 +49,10 @@ public class CommandTick extends CommandCarpetBase {
     @Override
     @ParametersAreNonnullByDefault
     public void execute(final MinecraftServer server, final ICommandSender sender, String[] args) throws CommandException {
-        if (!command_enabled("commandTick", sender)) return;
+        if (!command_enabled("commandTick", sender)) {
+            Messenger.m(sender, "d Do not cheat! Use command ", "y \"/profile\"", "d  instead");
+            return;
+        }
         if (args.length == 0) {
             throw new WrongUsageException(getUsage(sender));
         }

--- a/carpetmodSrc/carpet/logging/LoggerRegistry.java
+++ b/carpetmodSrc/carpet/logging/LoggerRegistry.java
@@ -1,10 +1,7 @@
 package carpet.logging;
 
 import carpet.CarpetSettings;
-import carpet.logging.logHelpers.LightCheckReporter;
-import carpet.logging.logHelpers.PathReporter;
-import carpet.logging.logHelpers.RNGMonitor;
-import carpet.logging.logHelpers.TickWarpLogger;
+import carpet.logging.logHelpers.*;
 import com.google.common.base.Charsets;
 import com.google.gson.*;
 import net.minecraft.entity.player.EntityPlayer;
@@ -71,7 +68,7 @@ public class LoggerRegistry {
         registerLogger(PathReporter.NAME, new Logger(server, PathReporter.NAME, PathReporter.DEFAULT_OPTION, PathReporter.LOGGER_OPTIONS, LogHandler.CHAT));
 
         registerLogger("autosave", new Logger(server, "autosave", null, null, LogHandler.HUD));
-        registerLogger("tps", new Logger(server, "tps", null, null, LogHandler.HUD));
+        registerLogger(TPSLogHelper.NAME, new Logger(server, TPSLogHelper.NAME, TPSLogHelper.DEFAULT_OPTION, TPSLogHelper.LOGGER_OPTIONS, LogHandler.HUD));
         registerLogger("packets", new Logger(server, "packets", null, null, LogHandler.HUD));
         registerLogger("counter", new Logger(server, "counter", "white", new String[]{"all", "cactus", "white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray", "silver", "cyan", "purple", "blue", "brown", "green", "red", "black"}, LogHandler.HUD));
         registerLogger("mobcaps", new Logger(server, "mobcaps", "dynamic", new String[]{"dynamic", "overworld", "nether", "end"}, LogHandler.HUD));

--- a/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
+++ b/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
@@ -32,18 +32,24 @@ public class TPSLogHelper {
             ITextComponent[] message = new ITextComponent[1];
             double msptWarping = Double.NaN;
             double msptActual = Double.NaN;
+            boolean warping = TickSpeed.time_bias > 0;
             switch (option) {
                 case "average":
                 case "sample":
                     msptWarping = MathHelper.average(server.tickTimeArray) * 1.0E-6D;
-                    long minInterval = (TickSpeed.time_bias > 0 ? 0L : TickSpeed.mspt) * 1_000_000L;
-                    msptActual = get_limited_average(server.tickTimeArray, minInterval, Long.MAX_VALUE) * 1.0E-6D;
+                    if (warping) {
+                        msptActual = msptWarping;
+                    } else {
+                        long stdInterval = TickSpeed.mspt * 1_000_000L;
+                        msptActual = get_average_truncated(server.tickTimeArray, stdInterval, Long.MAX_VALUE) * 1.0E-6D;
+                    }
                     break;
                 case "peak":
             }
             double tpsActual = 1000.0 / msptActual;
             String colorMspt = Messenger.heatmap_color(msptWarping, TickSpeed.mspt);
-            String colorTps = Messenger.heatmap_color(msptActual, TickSpeed.mspt);
+            String colorTps = (warping || msptActual <= TickSpeed.mspt || msptWarping > TickSpeed.mspt)
+                    ? colorMspt : Messenger.heatmap_color(msptActual, TickSpeed.mspt);
             message[0] = Messenger.m(null,
                     "g TPS: ", String.format(Locale.US, "%s %.1f", colorTps, tpsActual),
                     "g  MSPT: ", String.format(Locale.US, "%s %.1f", colorMspt, msptWarping));
@@ -53,15 +59,53 @@ public class TPSLogHelper {
         }, "MSPT", pair[0], "TPS", pair[1]);
     }
 
-    public static double get_limited_average(long[] values, long floor, long ceil) {
-        if (values == null) {
+    public static double get_average_truncated(long[] values, long floor, long ceil) {
+        if (values == null || floor > ceil) {
             return Double.NaN;
         }
         long sum = 0L;
-        for (long elem : values) {
-            long value = Math.min(Math.max(elem, floor), ceil);
+        int lowers = 0;
+        int uppers = 0;
+        for (long value : values) {
+            if (value < floor) {
+                value = floor;
+                ++lowers;
+            } else if (value > ceil) {
+                value = ceil;
+                ++uppers;
+            }
             sum += value;
         }
-        return (double) sum / (double) values.length;
+        if (lowers == values.length) {
+            return floor;
+        } else if (uppers == values.length) {
+            return ceil;
+        }
+        return (double) sum / values.length;
+    }
+
+    public static double get_max_truncated(long[] values, long floor, long ceil) {
+        if (values == null || floor > ceil) {
+            return Double.NaN;
+        }
+        long sum = 0L;
+        int lowers = 0;
+        int uppers = 0;
+        for (long value : values) {
+            if (value < floor) {
+                value = floor;
+                ++lowers;
+            } else if (value > ceil) {
+                value = ceil;
+                ++uppers;
+            }
+            sum += value;
+        }
+        if (lowers == values.length) {
+            return floor;
+        } else if (uppers == values.length) {
+            return ceil;
+        }
+        return (double) sum / values.length;
     }
 }

--- a/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
+++ b/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
@@ -38,7 +38,7 @@ public class TPSLogHelper {
             long[] sampleTimesArray = server.tickTimeArray;
             switch (option) {
                 case "sample":
-                    sampleTimesArray = copy_partial_stats(server);
+                    sampleTimesArray = get_partial_stats(server);
                 case "average":
                     msptWarping = MathHelper.average(sampleTimesArray) * 1.0E-6D;
                     if (warping) {
@@ -49,8 +49,8 @@ public class TPSLogHelper {
                     }
                     break;
                 case "peak":
-                    sampleTimesArray = copy_partial_stats(server);
-                    msptWarping = get_max_truncated(sampleTimesArray, 0, Long.MAX_VALUE) * 1.0E-6D;
+                    sampleTimesArray = get_partial_stats(server);
+                    msptWarping = get_max(sampleTimesArray) * 1.0E-6D;
                     if (warping) {
                         msptActual = msptWarping;
                     } else {
@@ -114,9 +114,24 @@ public class TPSLogHelper {
         return maxVal;
     }
 
-    @Nonnull
-    public static long[] copy_partial_stats(@Nonnull MinecraftServer server) {
-        int length = Math.min(Math.max(1, CarpetSettings.HUDUpdateInterval), server.tickTimeArray.length);
+    public static long get_max(long[] values) {
+        if (values == null) {
+            return Long.MIN_VALUE;
+        }
+        long maxVal = Long.MIN_VALUE;
+        for (long value : values) {
+            if (value > maxVal) {
+                maxVal = value;
+            }
+        }
+        return maxVal;
+    }
+
+    public static long[] get_partial_stats(@Nonnull MinecraftServer server) {
+        int length = Math.max(1, CarpetSettings.HUDUpdateInterval);
+        if (length >= server.tickTimeArray.length) {
+            return server.tickTimeArray;
+        }
         long[] sampleTimesArray = new long[length];
         for (int i = 0, t = server.getTickCounter(); i < length; ++i) {
             sampleTimesArray[i] = server.tickTimeArray[--t % server.tickTimeArray.length];

--- a/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
+++ b/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
@@ -1,0 +1,67 @@
+package carpet.logging.logHelpers;
+
+import carpet.helpers.TickSpeed;
+import carpet.logging.Logger;
+import carpet.logging.LoggerRegistry;
+import carpet.utils.Messenger;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.ITextComponent;
+
+import java.util.Locale;
+
+public class TPSLogHelper {
+    public static final String[] LOGGER_OPTIONS = new String[]{"sample", "peak", "average"};
+    public static final String DEFAULT_OPTION = LOGGER_OPTIONS[0];
+    public static final String NAME = "tps";
+    private static Logger instance = null;
+
+    public static Logger get_instance() {
+        if (instance == null) {
+            instance = LoggerRegistry.getLogger(NAME);
+        }
+        return instance;
+    }
+
+    public static void update_log_HUD(MinecraftServer server) {
+        if (server == null) {
+            return;
+        }
+        double[] pair = new double[2];
+        get_instance().log(option -> {
+            ITextComponent[] message = new ITextComponent[1];
+            double msptWarping = Double.NaN;
+            double msptActual = Double.NaN;
+            switch (option) {
+                case "average":
+                case "sample":
+                    msptWarping = MathHelper.average(server.tickTimeArray) * 1.0E-6D;
+                    long minInterval = (TickSpeed.time_bias > 0 ? 0L : TickSpeed.mspt) * 1_000_000L;
+                    msptActual = get_limited_average(server.tickTimeArray, minInterval, Long.MAX_VALUE) * 1.0E-6D;
+                    break;
+                case "peak":
+            }
+            double tpsActual = 1000.0 / msptActual;
+            String colorMspt = Messenger.heatmap_color(msptWarping, TickSpeed.mspt);
+            String colorTps = Messenger.heatmap_color(msptActual, TickSpeed.mspt);
+            message[0] = Messenger.m(null,
+                    "g TPS: ", String.format(Locale.US, "%s %.1f", colorTps, tpsActual),
+                    "g  MSPT: ", String.format(Locale.US, "%s %.1f", colorMspt, msptWarping));
+            pair[0] = msptWarping;
+            pair[1] = tpsActual;
+            return message;
+        }, "MSPT", pair[0], "TPS", pair[1]);
+    }
+
+    public static double get_limited_average(long[] values, long floor, long ceil) {
+        if (values == null) {
+            return Double.NaN;
+        }
+        long sum = 0L;
+        for (long elem : values) {
+            long value = Math.min(Math.max(elem, floor), ceil);
+            sum += value;
+        }
+        return (double) sum / (double) values.length;
+    }
+}

--- a/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
+++ b/carpetmodSrc/carpet/logging/logHelpers/TPSLogHelper.java
@@ -52,10 +52,10 @@ public class TPSLogHelper {
                     sampleTimesArray = get_partial_stats(server);
                     msptWarping = get_max(sampleTimesArray) * 1.0E-6D;
                     if (warping) {
-                        msptActual = msptWarping;
+                        msptActual = MathHelper.average(sampleTimesArray) * 1.0E-6D;
                     } else {
                         long stdInterval = TickSpeed.mspt * 1_000_000L;
-                        msptActual = get_max_truncated(sampleTimesArray, stdInterval, Long.MAX_VALUE) * 1.0E-6D;
+                        msptActual = get_average_truncated(sampleTimesArray, stdInterval, Long.MAX_VALUE) * 1.0E-6D;
                     }
                     break;
             }
@@ -97,6 +97,7 @@ public class TPSLogHelper {
         return (double) sum / values.length;
     }
 
+    @SuppressWarnings("unused")
     public static long get_max_truncated(long[] values, long floor, long ceil) {
         if (floor > ceil) {
             return ceil;

--- a/carpetmodSrc/carpet/logging/logHelpers/TickWarpLogger.java
+++ b/carpetmodSrc/carpet/logging/logHelpers/TickWarpLogger.java
@@ -31,7 +31,7 @@ public class TickWarpLogger {
 
     public static void update_log_HUD() {
         if (TickSpeed.time_bias > 0) {
-            get_instance().log((option, player) -> {
+            get_instance().log(option -> {
                 long totalTicks = TickSpeed.time_warp_scheduled_ticks;
                 long doneTicks = totalTicks - TickSpeed.time_bias;
                 double progressRate = (double) doneTicks / Math.max(totalTicks, 1);

--- a/carpetmodSrc/carpet/utils/CarpetProfiler.java
+++ b/carpetmodSrc/carpet/utils/CarpetProfiler.java
@@ -218,7 +218,9 @@ public class CarpetProfiler {
         //print stats
         final long total_tick_time = time_repo.get("tick");
         final double divider = 1.0D / tick_health_requested / 1000000;
-        print_stat_line(server, 0, "Average tick time", divider * total_tick_time);
+        String literal = String.format("%.3f", divider * total_tick_time);
+        Messenger.print_server_message(server,
+                "Average tick time: " + literal + "ms (in " + tick_health_requested + " ticks)");
         long accumulated_total = 0L;
         long value;
 

--- a/carpetmodSrc/carpet/utils/CarpetProfiler.java
+++ b/carpetmodSrc/carpet/utils/CarpetProfiler.java
@@ -10,9 +10,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class CarpetProfiler
-{
-    private static final HashMap<String, Long> time_repo = new HashMap<String, Long>();
+public class CarpetProfiler {
+    private static final HashMap<String, Long> time_repo = new HashMap<>();
     public static int tick_health_requested = 0;
     private static int tick_health_elapsed = 0;
     private static int test_type = 0; //1 for ticks, 2 for entities;
@@ -20,29 +19,28 @@ public class CarpetProfiler
     private static long current_section_start = 0;
     private static long current_tick_start = 0;
 
-    public static void prepare_tick_report(int ticks)
-    {
+    public static void prepare_tick_report(int ticks) {
         //maybe add so it only spams the sending player, but honestly - all may want to see it
         time_repo.clear();
         test_type = 1;
-        time_repo.put("tick",0L);
-        time_repo.put("Network",0L);
-        time_repo.put("Autosave",0L);
+        time_repo.put("tick", 0L);
+        time_repo.put("Network", 0L);
+        time_repo.put("Autosave", 0L);
 
-        time_repo.put("overworld.spawning",0L);
-        time_repo.put("overworld.blocks",0L);
-        time_repo.put("overworld.entities",0L);
-        time_repo.put("overworld.tileentities",0L);
+        time_repo.put("overworld.spawning", 0L);
+        time_repo.put("overworld.blocks", 0L);
+        time_repo.put("overworld.entities", 0L);
+        time_repo.put("overworld.tileentities", 0L);
 
-        time_repo.put("the_nether.spawning",0L);
-        time_repo.put("the_nether.blocks",0L);
-        time_repo.put("the_nether.entities",0L);
-        time_repo.put("the_nether.tileentities",0L);
+        time_repo.put("the_nether.spawning", 0L);
+        time_repo.put("the_nether.blocks", 0L);
+        time_repo.put("the_nether.entities", 0L);
+        time_repo.put("the_nether.tileentities", 0L);
 
-        time_repo.put("the_end.spawning",0L);
-        time_repo.put("the_end.blocks",0L);
-        time_repo.put("the_end.entities",0L);
-        time_repo.put("the_end.tileentities",0L);
+        time_repo.put("the_end.spawning", 0L);
+        time_repo.put("the_end.blocks", 0L);
+        time_repo.put("the_end.entities", 0L);
+        time_repo.put("the_end.tileentities", 0L);
         //spawning
         //blocks
         //entities
@@ -56,149 +54,120 @@ public class CarpetProfiler
 
     }
 
-    public static void start_section(String dimension, String name)
-    {
-        if (tick_health_requested == 0L || test_type != 1)
-        {
+    public static void start_section(String dimension, String name) {
+        if (tick_health_requested == 0L || test_type != 1) {
             return;
         }
-        if (current_tick_start == 0L)
-        {
+        if (current_tick_start == 0L) {
             return;
         }
-        if (current_section != null)
-        {
+        if (current_section != null) {
             end_current_section();
         }
         String key = name;
-        if (dimension != null)
-        {
-            key = dimension+"."+name;
+        if (dimension != null) {
+            key = dimension + "." + name;
         }
         current_section = key;
         current_section_start = System.nanoTime();
     }
 
-    public static void start_entity_section(String dimension, Entity e)
-    {
-        if (tick_health_requested == 0L || test_type != 2)
-        {
+    public static void start_entity_section(String dimension, Entity e) {
+        if (tick_health_requested == 0L || test_type != 2) {
             return;
         }
-        if (current_tick_start == 0L)
-        {
+        if (current_tick_start == 0L) {
             return;
         }
-        if (current_section != null)
-        {
+        if (current_section != null) {
             end_current_section();
         }
-        current_section = dimension+"."+e.cm_name();
+        current_section = dimension + "." + e.cm_name();
         current_section_start = System.nanoTime();
     }
 
-    public static void start_tileentity_section(String dimension, TileEntity e)
-    {
-        if (tick_health_requested == 0L || test_type != 2)
-        {
+    public static void start_tileentity_section(String dimension, TileEntity e) {
+        if (tick_health_requested == 0L || test_type != 2) {
             return;
         }
-        if (current_tick_start == 0L)
-        {
+        if (current_tick_start == 0L) {
             return;
         }
-        if (current_section != null)
-        {
+        if (current_section != null) {
             end_current_section();
         }
-        current_section = dimension+"."+e.cm_name();
+        current_section = dimension + "." + e.cm_name();
         current_section_start = System.nanoTime();
     }
 
-    public static void end_current_section()
-    {
-        if (tick_health_requested == 0L || test_type != 1)
-        {
+    public static void end_current_section() {
+        if (tick_health_requested == 0L || test_type != 1) {
             return;
         }
         long end_time = System.nanoTime();
-        if (current_tick_start == 0L)
-        {
+        if (current_tick_start == 0L) {
             return;
         }
-        if (current_section == null)
-        {
+        if (current_section == null) {
             CarpetSettings.LOG.error("finishing section that hasn't started");
             return;
         }
         //CarpetSettings.LOG.error("finishing section "+current_section);
-        time_repo.put(current_section,time_repo.get(current_section)+end_time-current_section_start);
+        time_repo.put(current_section, time_repo.get(current_section) + end_time - current_section_start);
         current_section = null;
         current_section_start = 0;
     }
 
-    public static void end_current_entity_section()
-    {
-        if (tick_health_requested == 0L || test_type != 2)
-        {
+    public static void end_current_entity_section() {
+        if (tick_health_requested == 0L || test_type != 2) {
             return;
         }
         long end_time = System.nanoTime();
-        if (current_tick_start == 0L)
-        {
+        if (current_tick_start == 0L) {
             return;
         }
-        if (current_section == null)
-        {
+        if (current_section == null) {
             CarpetSettings.LOG.error("finishing section that hasn't started");
             return;
         }
         //CarpetSettings.LOG.error("finishing section "+current_section);
-        String time_section = "t."+current_section;
-        String count_section = "c."+current_section;
-        time_repo.put(time_section,time_repo.getOrDefault(time_section,0L)+end_time-current_section_start);
-        time_repo.put(count_section,time_repo.getOrDefault(count_section,0L)+1);
+        String time_section = "t." + current_section;
+        String count_section = "c." + current_section;
+        time_repo.put(time_section, time_repo.getOrDefault(time_section, 0L) + end_time - current_section_start);
+        time_repo.put(count_section, time_repo.getOrDefault(count_section, 0L) + 1);
         current_section = null;
         current_section_start = 0;
     }
 
-    public static void start_tick_profiling()
-    {
+    public static void start_tick_profiling() {
         current_tick_start = System.nanoTime();
     }
 
-    public static void end_tick_profiling(MinecraftServer server)
-    {
-        if (current_tick_start == 0L)
-        {
+    public static void end_tick_profiling(MinecraftServer server) {
+        if (current_tick_start == 0L) {
             return;
         }
-        time_repo.put("tick",time_repo.get("tick")+System.nanoTime()-current_tick_start);
-        tick_health_elapsed --;
+        time_repo.put("tick", time_repo.get("tick") + System.nanoTime() - current_tick_start);
+        tick_health_elapsed--;
         //CarpetSettings.LOG.error("tick count current at "+time_repo.get("tick"));
-        if (tick_health_elapsed <= 0)
-        {
+        if (tick_health_elapsed <= 0) {
             finalize_tick_report(server);
         }
     }
 
-    public static void finalize_tick_report(MinecraftServer server)
-    {
-        if (test_type == 1)
-        {
+    public static void finalize_tick_report(MinecraftServer server) {
+        if (test_type == 1) {
             finalize_tick_report_for_time(server);
         }
-        if (test_type == 2)
-        {
+        if (test_type == 2) {
             finalize_tick_report_for_entities(server);
         }
         cleanup_tick_report();
     }
 
-    public static void cleanup_tick_report()
-    {
+    public static void cleanup_tick_report() {
         time_repo.clear();
-        time_repo.put("tick",0L);
+        time_repo.put("tick", 0L);
         test_type = 0;
         tick_health_elapsed = 0;
         tick_health_requested = 0;
@@ -208,118 +177,109 @@ public class CarpetProfiler
 
     }
 
-    public static void finalize_tick_report_for_time(MinecraftServer server)
-    {
+    public static void finalize_tick_report_for_time(MinecraftServer server) {
         //print stats
         long total_tick_time = time_repo.get("tick");
-        double divider = 1.0D/tick_health_requested/1000000;
-        Messenger.print_server_message(server, String.format("Average tick time: %.3fms",divider*total_tick_time));
+        double divider = 1.0D / tick_health_requested / 1000000;
+        Messenger.print_server_message(server, String.format("Average tick time: %.3fms", divider * total_tick_time));
         long accumulated = 0L;
 
         accumulated += time_repo.get("Autosave");
-        Messenger.print_server_message(server, String.format("Autosave: %.3fms",divider*time_repo.get("Autosave")));
+        Messenger.print_server_message(server, String.format("Autosave: %.3fms", divider * time_repo.get("Autosave")));
 
         accumulated += time_repo.get("Network");
-        Messenger.print_server_message(server, String.format("Network: %.3fms",divider*time_repo.get("Network")));
+        Messenger.print_server_message(server, String.format("Network: %.3fms", divider * time_repo.get("Network")));
 
         Messenger.print_server_message(server, "Overworld:");
 
         accumulated += time_repo.get("overworld.entities");
-        Messenger.print_server_message(server, String.format(" - Entities: %.3fms",divider*time_repo.get("overworld.entities")));
+        Messenger.print_server_message(server, String.format(" - Entities: %.3fms", divider * time_repo.get("overworld.entities")));
 
         accumulated += time_repo.get("overworld.tileentities");
-        Messenger.print_server_message(server, String.format(" - Tile Entities: %.3fms",divider*time_repo.get("overworld.tileentities")));
+        Messenger.print_server_message(server, String.format(" - Tile Entities: %.3fms", divider * time_repo.get("overworld.tileentities")));
 
         accumulated += time_repo.get("overworld.blocks");
-        Messenger.print_server_message(server, String.format(" - Blocks: %.3fms",divider*time_repo.get("overworld.blocks")));
+        Messenger.print_server_message(server, String.format(" - Blocks: %.3fms", divider * time_repo.get("overworld.blocks")));
 
         accumulated += time_repo.get("overworld.spawning");
-        Messenger.print_server_message(server, String.format(" - Spawning: %.3fms",divider*time_repo.get("overworld.spawning")));
+        Messenger.print_server_message(server, String.format(" - Spawning: %.3fms", divider * time_repo.get("overworld.spawning")));
 
         Messenger.print_server_message(server, "Nether:");
 
         accumulated += time_repo.get("the_nether.entities");
-        Messenger.print_server_message(server, String.format(" - Entities: %.3fms",divider*time_repo.get("the_nether.entities")));
+        Messenger.print_server_message(server, String.format(" - Entities: %.3fms", divider * time_repo.get("the_nether.entities")));
 
         accumulated += time_repo.get("the_nether.tileentities");
-        Messenger.print_server_message(server, String.format(" - Tile Entities: %.3fms",divider*time_repo.get("the_nether.tileentities")));
+        Messenger.print_server_message(server, String.format(" - Tile Entities: %.3fms", divider * time_repo.get("the_nether.tileentities")));
 
         accumulated += time_repo.get("the_nether.blocks");
-        Messenger.print_server_message(server, String.format(" - Blocks: %.3fms",divider*time_repo.get("the_nether.blocks")));
+        Messenger.print_server_message(server, String.format(" - Blocks: %.3fms", divider * time_repo.get("the_nether.blocks")));
 
         accumulated += time_repo.get("the_nether.spawning");
-        Messenger.print_server_message(server, String.format(" - Spawning: %.3fms",divider*time_repo.get("the_nether.spawning")));
+        Messenger.print_server_message(server, String.format(" - Spawning: %.3fms", divider * time_repo.get("the_nether.spawning")));
 
         Messenger.print_server_message(server, "End:");
 
         accumulated += time_repo.get("the_end.entities");
-        Messenger.print_server_message(server, String.format(" - Entities: %.3fms",divider*time_repo.get("the_end.entities")));
+        Messenger.print_server_message(server, String.format(" - Entities: %.3fms", divider * time_repo.get("the_end.entities")));
 
         accumulated += time_repo.get("the_end.tileentities");
-        Messenger.print_server_message(server, String.format(" - Tile Entities: %.3fms",divider*time_repo.get("the_end.tileentities")));
+        Messenger.print_server_message(server, String.format(" - Tile Entities: %.3fms", divider * time_repo.get("the_end.tileentities")));
 
         accumulated += time_repo.get("the_end.blocks");
-        Messenger.print_server_message(server, String.format(" - Blocks: %.3fms",divider*time_repo.get("the_end.blocks")));
+        Messenger.print_server_message(server, String.format(" - Blocks: %.3fms", divider * time_repo.get("the_end.blocks")));
 
         accumulated += time_repo.get("the_end.spawning");
-        Messenger.print_server_message(server, String.format(" - Spawning: %.3fms",divider*time_repo.get("the_end.spawning")));
+        Messenger.print_server_message(server, String.format(" - Spawning: %.3fms", divider * time_repo.get("the_end.spawning")));
 
-        long rest = total_tick_time-accumulated;
+        long rest = total_tick_time - accumulated;
 
-        Messenger.print_server_message(server, String.format("Rest: %.3fms",divider*rest));
+        Messenger.print_server_message(server, String.format("Rest: %.3fms", divider * rest));
     }
 
-    public static void finalize_tick_report_for_entities(MinecraftServer server)
-    {
+    public static void finalize_tick_report_for_entities(MinecraftServer server) {
         //print stats
         long total_tick_time = time_repo.get("tick");
-        double divider = 1.0D/tick_health_requested/1000000;
-        Messenger.print_server_message(server, String.format("Average tick time: %.3fms",divider*total_tick_time));
+        double divider = 1.0D / tick_health_requested / 1000000;
+        Messenger.print_server_message(server, String.format("Average tick time: %.3fms", divider * total_tick_time));
         time_repo.remove("tick");
         Messenger.print_server_message(server, "Top 10 counts:");
         int total = 0;
-        for ( Map.Entry<String, Long> entry : time_repo.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList()) )
-        {
-            if (entry.getKey().startsWith("t."))
-            {
+        for (Map.Entry<String, Long> entry : time_repo.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList())) {
+            if (entry.getKey().startsWith("t.")) {
                 continue;
             }
             total++;
-            if (total > 10)
-            {
+            if (total > 10) {
                 continue;
             }
             String[] parts = entry.getKey().split("\\.");
             String dim = parts[1];
             String name = parts[2];
-            Messenger.print_server_message(server, String.format(" - %s in %s: %.3f",name, dim, 1.0D*entry.getValue()/tick_health_requested));
+            Messenger.print_server_message(server, String.format(" - %s in %s: %.3f", name, dim, 1.0D * entry.getValue() / tick_health_requested));
         }
         Messenger.print_server_message(server, "Top 10 grossing:");
         total = 0;
-        for ( Map.Entry<String, Long> entry : time_repo.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList()) )
-        {
-            if (entry.getKey().startsWith("c."))
-            {
+        for (Map.Entry<String, Long> entry : time_repo.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList())) {
+            if (entry.getKey().startsWith("c.")) {
                 continue;
             }
             total++;
-            if (total > 10)
-            {
+            if (total > 10) {
                 continue;
             }
             String[] parts = entry.getKey().split("\\.");
             String dim = parts[1];
             String name = parts[2];
-            Messenger.print_server_message(server, String.format(" - %s in %s: %.3fms",name, dim, divider*entry.getValue()));
+            Messenger.print_server_message(server, String.format(" - %s in %s: %.3fms", name, dim, divider * entry.getValue()));
         }
 
     }
 
-    public static void prepare_entity_report(int ticks)
-    {
+    public static void prepare_entity_report(int ticks) {
         //maybe add so it only spams the sending player, but honestly - all may want to see it
         time_repo.clear();
-        time_repo.put("tick",0L);
+        time_repo.put("tick", 0L);
         test_type = 2;
         tick_health_elapsed = ticks;
         tick_health_requested = ticks;

--- a/carpetmodSrc/carpet/utils/CarpetProfiler.java
+++ b/carpetmodSrc/carpet/utils/CarpetProfiler.java
@@ -24,8 +24,8 @@ public class CarpetProfiler {
         time_repo.clear();
         test_type = 1;
         time_repo.put("tick", 0L);
-        time_repo.put("Network", 0L);
-        time_repo.put("Autosave", 0L);
+        time_repo.put("network", 0L);
+        time_repo.put("autosave", 0L);
 
         time_repo.put("overworld.spawning", 0L);
         time_repo.put("overworld.blocks", 0L);
@@ -184,11 +184,11 @@ public class CarpetProfiler {
         Messenger.print_server_message(server, String.format("Average tick time: %.3fms", divider * total_tick_time));
         long accumulated = 0L;
 
-        accumulated += time_repo.get("Autosave");
-        Messenger.print_server_message(server, String.format("Autosave: %.3fms", divider * time_repo.get("Autosave")));
+        accumulated += time_repo.get("autosave");
+        Messenger.print_server_message(server, String.format("Autosave: %.3fms", divider * time_repo.get("autosave")));
 
-        accumulated += time_repo.get("Network");
-        Messenger.print_server_message(server, String.format("Network: %.3fms", divider * time_repo.get("Network")));
+        accumulated += time_repo.get("network");
+        Messenger.print_server_message(server, String.format("Network: %.3fms", divider * time_repo.get("network")));
 
         Messenger.print_server_message(server, "Overworld:");
 

--- a/carpetmodSrc/carpet/utils/HUDController.java
+++ b/carpetmodSrc/carpet/utils/HUDController.java
@@ -5,6 +5,7 @@ import carpet.helpers.HopperCounter;
 import carpet.helpers.TickSpeed;
 import carpet.logging.LoggerRegistry;
 import carpet.logging.logHelpers.PacketCounter;
+import carpet.logging.logHelpers.TPSLogHelper;
 import carpet.logging.logHelpers.TickWarpLogger;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.player.EntityPlayer;
@@ -59,7 +60,7 @@ public class HUDController
             log_autosave(server);
 
         if (LoggerRegistry.__tps)
-            log_tps(server);
+            TPSLogHelper.update_log_HUD(server);
 
         if (LoggerRegistry.__mobcaps)
             log_mobcaps();
@@ -104,7 +105,8 @@ public class HUDController
         LoggerRegistry.getLogger("autosave").log(() -> message, "Prev", previous, "Next", next);
     }
 
-    private static void log_tps(MinecraftServer server)
+    @Deprecated
+    private static void log_tps_legacy(MinecraftServer server)
     {
         double MSPT = MathHelper.average(server.tickTimeArray) * 1.0E-6D;
         double TPS = 1000.0D / Math.max((TickSpeed.time_warp_start_time != 0)?0.0:TickSpeed.mspt, MSPT);
@@ -112,7 +114,7 @@ public class HUDController
         ITextComponent[] message = new ITextComponent[]{Messenger.m(null,
                 "g TPS: ", String.format(Locale.US, "%s %.1f",color, TPS),
                 "g  MSPT: ", String.format(Locale.US,"%s %.1f", color, MSPT))};
-        LoggerRegistry.getLogger("tps").log(() -> message, "MSPT", MSPT, "TPS", TPS);
+        TPSLogHelper.get_instance().log(() -> message, "MSPT", MSPT, "TPS", TPS);
     }
 
     private static void log_mobcaps()

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -208,15 +208,12 @@
                      this.field_71296_Q = true;
                  }
              }
-@@ -594,6 +660,15 @@
+@@ -594,6 +660,12 @@
          long i = System.nanoTime();
          ++this.field_71315_w;
  
++        CarpetProfiler.start_tick_profiling();
 +        CarpetServer.tick(this);
-+        if (CarpetProfiler.tick_health_requested != 0L)
-+        {
-+            CarpetProfiler.start_tick_profiling();
-+        }
 +
 +        CarpetServer.rsmmServer.tickStart(); // RSMM
 +        WorldHelper.startTickTask(TickTask.TICK); // RSMM
@@ -224,7 +221,7 @@
          if (this.field_71295_T)
          {
              this.field_71295_T = false;
-@@ -620,13 +695,23 @@
+@@ -620,13 +692,23 @@
              this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
          }
  
@@ -248,7 +245,7 @@
  
          this.field_71304_b.func_76320_a("tallying");
          this.field_71311_j[this.field_71315_w % 100] = System.nanoTime() - i;
-@@ -645,12 +730,39 @@
+@@ -645,12 +727,35 @@
  
          this.field_71304_b.func_76319_b();
          this.field_71304_b.func_76319_b();
@@ -262,11 +259,7 @@
 +        }
 +
 +        LagSpikeHelper.processLagSpikes(null, LagSpikeHelper.TickPhase.TICK, LagSpikeHelper.PrePostSubPhase.POST);
-+
-+        if (CarpetProfiler.tick_health_requested != 0L)
-+        {
-+            CarpetProfiler.end_tick_profiling(this);
-+        }
++        CarpetProfiler.end_tick_profiling(this);
 +
 +        if(CarpetSettings.scoreboardDelta > 0 && field_71315_w % 20 == 0){
 +            ScoreboardDelta.update();
@@ -288,7 +281,7 @@
          synchronized (this.field_175589_i)
          {
              while (!this.field_175589_i.isEmpty())
-@@ -658,8 +770,10 @@
+@@ -658,8 +763,10 @@
                  Util.func_181617_a(this.field_175589_i.poll(), field_147145_h);
              }
          }
@@ -299,7 +292,7 @@
  
          for (int j = 0; j < this.field_71305_c.length; ++j)
          {
-@@ -672,6 +786,7 @@
+@@ -672,6 +779,7 @@
                  {
                      return worldserver.func_72912_H().func_76065_j();
                  });
@@ -307,7 +300,7 @@
  
                  if (this.field_71315_w % 20 == 0)
                  {
-@@ -686,27 +801,46 @@
+@@ -686,27 +794,46 @@
                  {
                      worldserver.func_72835_b();
                  }
@@ -356,7 +349,7 @@
                  this.field_71304_b.func_76319_b();
                  this.field_71304_b.func_76319_b();
              }
-@@ -714,13 +848,19 @@
+@@ -714,13 +841,19 @@
              this.field_71312_k[j][this.field_71315_w % 100] = System.nanoTime() - i;
          }
  
@@ -376,7 +369,7 @@
  
          for (int k = 0; k < this.field_71322_p.size(); ++k)
          {
-@@ -728,6 +868,9 @@
+@@ -728,6 +861,9 @@
          }
  
          this.field_71304_b.func_76319_b();
@@ -386,7 +379,7 @@
      }
  
      public boolean func_71255_r()
-@@ -939,7 +1082,7 @@
+@@ -939,7 +1075,7 @@
  
      public String getServerModName()
      {
@@ -395,7 +388,7 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -1512,6 +1655,7 @@
+@@ -1512,6 +1648,7 @@
      {
          if (this.func_152345_ab())
          {
@@ -403,7 +396,7 @@
              this.func_184103_al().func_72389_g();
              this.field_71305_c[0].func_184146_ak().func_186522_a();
              this.func_191949_aK().func_192779_a();
-@@ -1523,4 +1667,9 @@
+@@ -1523,4 +1660,9 @@
              this.func_152344_a(this::func_193031_aM);
          }
      }

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -281,7 +281,7 @@
          synchronized (this.field_175589_i)
          {
              while (!this.field_175589_i.isEmpty())
-@@ -658,8 +763,10 @@
+@@ -658,11 +763,14 @@
                  Util.func_181617_a(this.field_175589_i.poll(), field_147145_h);
              }
          }
@@ -292,7 +292,11 @@
  
          for (int j = 0; j < this.field_71305_c.length; ++j)
          {
-@@ -672,6 +779,7 @@
++            CarpetProfiler.start_dimension(CarpetProfiler.get_dim_key(j));
+             long i = System.nanoTime();
+ 
+             if (j == 0 || this.func_71255_r())
+@@ -672,6 +780,7 @@
                  {
                      return worldserver.func_72912_H().func_76065_j();
                  });
@@ -300,7 +304,7 @@
  
                  if (this.field_71315_w % 20 == 0)
                  {
-@@ -686,27 +794,46 @@
+@@ -686,41 +795,67 @@
                  {
                      worldserver.func_72835_b();
                  }
@@ -349,8 +353,9 @@
                  this.field_71304_b.func_76319_b();
                  this.field_71304_b.func_76319_b();
              }
-@@ -714,13 +841,19 @@
+ 
              this.field_71312_k[j][this.field_71315_w % 100] = System.nanoTime() - i;
++            CarpetProfiler.end_current_dimension();
          }
  
 +        CarpetProfiler.start_section(null, "network");
@@ -369,7 +374,7 @@
  
          for (int k = 0; k < this.field_71322_p.size(); ++k)
          {
-@@ -728,6 +861,9 @@
+@@ -728,6 +863,9 @@
          }
  
          this.field_71304_b.func_76319_b();
@@ -379,7 +384,7 @@
      }
  
      public boolean func_71255_r()
-@@ -939,7 +1075,7 @@
+@@ -939,7 +1077,7 @@
  
      public String getServerModName()
      {
@@ -388,7 +393,7 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -1512,6 +1648,7 @@
+@@ -1512,6 +1650,7 @@
      {
          if (this.func_152345_ab())
          {
@@ -396,7 +401,7 @@
              this.func_184103_al().func_72389_g();
              this.field_71305_c[0].func_184146_ak().func_186522_a();
              this.func_191949_aK().func_192779_a();
-@@ -1523,4 +1660,9 @@
+@@ -1523,4 +1662,9 @@
              this.func_152344_a(this::func_193031_aM);
          }
      }

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -231,7 +231,7 @@
 +        LagSpikeHelper.processLagSpikes(null, LagSpikeHelper.TickPhase.AUTOSAVE, LagSpikeHelper.PrePostSubPhase.PRE);
          if (this.field_71315_w % 900 == 0)
          {
-+            CarpetProfiler.start_section(null, "Autosave");
++            CarpetProfiler.start_section(null, "autosave");
              this.field_71304_b.func_76320_a("save");
 +            WorldHelper.startTickTask(TickTask.AUTOSAVE); // RSMM
 +            this.field_71318_t.storeFakePlayerData();
@@ -360,7 +360,7 @@
              this.field_71312_k[j][this.field_71315_w % 100] = System.nanoTime() - i;
          }
  
-+        CarpetProfiler.start_section(null, "Network");
++        CarpetProfiler.start_section(null, "network");
          this.field_71304_b.func_76318_c("connection");
 +        WorldHelper.swapTickTask(TickTask.CONNECTIONS); // RSMM
          this.func_147137_ag().func_151269_c();

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -386,7 +386,7 @@
          }
 +        LagSpikeHelper.processLagSpikes(this, LagSpikeHelper.TickPhase.ENTITY, LagSpikeHelper.EntitySubPhase.POST_NORMAL);
 +        CarpetProfiler.end_current_section();
-+        CarpetProfiler.start_section(world_name, "tileentities");
++        CarpetProfiler.start_section(world_name, "tile_entities");
  
          this.field_72984_F.func_76318_c("blockEntities");
 +        WorldHelper.swapTickTask(TickTask.BLOCK_ENTITIES); // RSMM

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -173,7 +173,7 @@
          int j = this.func_72967_a(1.0F);
  
          if (j != this.func_175657_ab())
-@@ -200,26 +286,101 @@
+@@ -200,26 +286,103 @@
              this.func_175692_b(j);
          }
  
@@ -205,7 +205,7 @@
 -        this.func_72955_a(false);
 +        WorldHelper.startTickTask(TickTask.SCHEDULED_TICKS); // RSMM
 +
-+        CarpetProfiler.start_section(world_name, "blocks");
++        CarpetProfiler.start_section(world_name, "tile_ticks");
 +
 +        LagSpikeHelper.processLagSpikes(this, LagSpikeHelper.TickPhase.TILE_TICK, LagSpikeHelper.PrePostSubPhase.PRE);
 +		this.func_72955_a(false);
@@ -224,7 +224,7 @@
 +		WorldHelper.endTickTask(); // RSMM
 +
 +		} //end indent
-+		CarpetProfiler.start_section(world_name, "blocks");
++		CarpetProfiler.start_section(world_name, "chunk_ticks");
          this.field_72984_F.func_76318_c("tickBlocks");
 +        WorldHelper.startTickTask(TickTask.TICK_CHUNKS); // RSMM
 +        LagSpikeHelper.processLagSpikes(this, LagSpikeHelper.TickPhase.RANDOM_TICK, LagSpikeHelper.PrePostSubPhase.PRE);
@@ -260,6 +260,7 @@
 +        }
          this.field_72984_F.func_76319_b();
 +
++        CarpetProfiler.start_section(world_name, "block_events");
 +        LagSpikeHelper.processLagSpikes(this, LagSpikeHelper.TickPhase.BLOCK_EVENT, LagSpikeHelper.PrePostSubPhase.PRE);
          this.func_147488_Z();
 +        LagSpikeHelper.processLagSpikes(this, LagSpikeHelper.TickPhase.BLOCK_EVENT, LagSpikeHelper.PrePostSubPhase.POST);
@@ -274,10 +275,11 @@
 +        if(CarpetSettings.setSeed != 0){
 +        	this.field_73012_v.setSeed(CarpetSettings.setSeed ^ 0x5DEECE66DL);
 +        }
++        CarpetProfiler.end_current_section();
      }
  
      @Nullable
-@@ -255,13 +416,22 @@
+@@ -255,13 +418,22 @@
                      ++j;
                  }
              }
@@ -302,7 +304,7 @@
          this.field_73068_P = false;
  
          for (EntityPlayer entityplayer : this.field_73010_i.stream().filter(EntityPlayer::func_70608_bn).collect(Collectors.toList()))
-@@ -273,6 +443,8 @@
+@@ -273,6 +445,8 @@
          {
              this.func_73051_P();
          }
@@ -311,7 +313,7 @@
      }
  
      private void func_73051_P()
-@@ -287,6 +459,28 @@
+@@ -287,6 +461,28 @@
      {
          if (this.field_73068_P && !this.field_72995_K)
          {
@@ -340,7 +342,7 @@
              for (EntityPlayer entityplayer : this.field_73010_i)
              {
                  if (!entityplayer.func_175149_v() && !entityplayer.func_71026_bH())
-@@ -303,7 +497,7 @@
+@@ -303,7 +499,7 @@
          }
      }
  
@@ -349,7 +351,7 @@
      {
          return this.func_72863_F().func_73149_a(p_175680_1_, p_175680_2_);
      }
-@@ -311,15 +505,84 @@
+@@ -311,15 +507,84 @@
      protected void func_184162_i()
      {
          this.field_72984_F.func_76320_a("playerCheckLight");
@@ -436,7 +438,7 @@
          }
  
          this.field_72984_F.func_76319_b();
-@@ -344,7 +607,13 @@
+@@ -344,7 +609,13 @@
              boolean flag = this.func_72896_J();
              boolean flag1 = this.func_72911_I();
              this.field_72984_F.func_76320_a("pollingChunks");
@@ -450,7 +452,7 @@
              for (Iterator<Chunk> iterator = this.field_73063_M.func_187300_b(); iterator.hasNext(); this.field_72984_F.func_76319_b())
              {
                  this.field_72984_F.func_76320_a("getChunk");
-@@ -354,10 +623,18 @@
+@@ -354,10 +625,18 @@
                  this.field_72984_F.func_76318_c("checkNextLight");
                  chunk.func_76594_o();
                  this.field_72984_F.func_76318_c("tickChunk");
@@ -470,7 +472,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int l = this.field_73005_l >> 2;
-@@ -384,8 +661,9 @@
+@@ -384,8 +663,9 @@
                  }
  
                  this.field_72984_F.func_76318_c("iceandsnow");
@@ -481,7 +483,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int j2 = this.field_73005_l >> 2;
-@@ -409,6 +687,7 @@
+@@ -409,6 +689,7 @@
                  }
  
                  this.field_72984_F.func_76318_c("tickBlocks");
@@ -489,7 +491,7 @@
  
                  if (i > 0)
                  {
-@@ -429,7 +708,15 @@
+@@ -429,7 +710,15 @@
  
                                  if (block.func_149653_t())
                                  {
@@ -506,7 +508,7 @@
                                  }
  
                                  this.field_72984_F.func_76319_b();
-@@ -437,13 +724,15 @@
+@@ -437,13 +726,15 @@
                          }
                      }
                  }
@@ -523,7 +525,7 @@
      {
          BlockPos blockpos = this.func_175725_q(p_175736_1_);
          AxisAlignedBB axisalignedbb = (new AxisAlignedBB(blockpos, new BlockPos(blockpos.func_177958_n(), this.func_72800_K(), blockpos.func_177952_p()))).func_186662_g(3.0D);
-@@ -472,13 +761,25 @@
+@@ -472,13 +763,25 @@
  
      public boolean func_175691_a(BlockPos p_175691_1_, Block p_175691_2_)
      {
@@ -551,7 +553,7 @@
          return this.field_73064_N.contains(nextticklistentry);
      }
  
-@@ -501,17 +802,29 @@
+@@ -501,17 +804,29 @@
  
                      if (iblockstate.func_185904_a() != Material.field_151579_a && iblockstate.func_177230_c() == p_175654_2_)
                      {
@@ -583,7 +585,7 @@
  
          if (this.func_175667_e(p_175654_1_))
          {
-@@ -531,7 +844,13 @@
+@@ -531,7 +846,13 @@
  
      public void func_180497_b(BlockPos p_180497_1_, Block p_180497_2_, int p_180497_3_, int p_180497_4_)
      {
@@ -598,7 +600,7 @@
          nextticklistentry.func_82753_a(p_180497_4_);
          Material material = p_180497_2_.func_176223_P().func_185904_a();
  
-@@ -549,7 +868,8 @@
+@@ -549,7 +870,8 @@
  
      public void func_72939_s()
      {
@@ -608,7 +610,7 @@
          {
              if (this.field_80004_Q++ >= 300)
              {
-@@ -567,6 +887,8 @@
+@@ -567,6 +889,8 @@
  
      protected void func_184147_l()
      {
@@ -617,7 +619,7 @@
          super.func_184147_l();
          this.field_72984_F.func_76318_c("players");
  
-@@ -621,6 +943,8 @@
+@@ -621,6 +945,8 @@
  
              this.field_72984_F.func_76319_b();
          }
@@ -626,7 +628,7 @@
      }
  
      public void func_82742_i()
-@@ -644,9 +968,18 @@
+@@ -644,9 +970,18 @@
              }
              else
              {
@@ -647,7 +649,7 @@
                  }
  
                  this.field_72984_F.func_76320_a("cleaning");
-@@ -677,12 +1010,15 @@
+@@ -677,12 +1012,15 @@
  
                      if (this.func_175707_a(nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0), nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0)))
                      {
@@ -663,7 +665,7 @@
                                  iblockstate.func_177230_c().func_180650_b(this, nextticklistentry1.field_180282_a, iblockstate, this.field_73012_v);
                              }
                              catch (Throwable throwable)
-@@ -699,6 +1035,7 @@
+@@ -699,6 +1037,7 @@
                          this.func_175684_a(nextticklistentry1.field_180282_a, nextticklistentry1.func_151351_a(), 0);
                      }
                  }
@@ -671,7 +673,7 @@
  
                  this.field_72984_F.func_76319_b();
                  this.field_94579_S.clear();
-@@ -950,11 +1287,18 @@
+@@ -950,11 +1289,18 @@
  
              chunkproviderserver.func_186027_a(p_73044_1_);
  
@@ -691,7 +693,7 @@
                  }
              }
          }
-@@ -1033,9 +1377,15 @@
+@@ -1033,9 +1379,15 @@
                  }
                  else
                  {
@@ -707,7 +709,7 @@
                          return false;
                      }
  
-@@ -1055,6 +1405,7 @@
+@@ -1055,6 +1407,7 @@
          this.field_175729_l.func_76038_a(p_72923_1_.func_145782_y(), p_72923_1_);
          this.field_175741_N.put(p_72923_1_.func_110124_au(), p_72923_1_);
          Entity[] aentity = p_72923_1_.func_70021_al();
@@ -715,7 +717,7 @@
  
          if (aentity != null)
          {
-@@ -1117,7 +1468,10 @@
+@@ -1117,7 +1470,10 @@
  
          for (EntityPlayer entityplayer : this.field_73010_i)
          {
@@ -727,7 +729,7 @@
              {
                  ((EntityPlayerMP)entityplayer).field_71135_a.func_147359_a(new SPacketExplosion(p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, explosion.func_180343_e(), (Vec3d)explosion.func_77277_b().get(entityplayer)));
              }
-@@ -1139,10 +1493,15 @@
+@@ -1139,10 +1495,15 @@
          }
  
          this.field_147490_S[this.field_147489_T].add(blockeventdata);
@@ -743,7 +745,7 @@
          while (!this.field_147490_S[this.field_147489_T].isEmpty())
          {
              int i = this.field_147489_T;
-@@ -1150,19 +1509,40 @@
+@@ -1150,19 +1511,40 @@
  
              for (BlockEventData blockeventdata : this.field_147490_S[i])
              {
@@ -785,7 +787,7 @@
          return iblockstate.func_177230_c() == p_147485_1_.func_151337_f() ? iblockstate.func_189547_a(this, p_147485_1_.func_180328_a(), p_147485_1_.func_151339_d(), p_147485_1_.func_151338_e()) : false;
      }
  
-@@ -1173,6 +1553,8 @@
+@@ -1173,6 +1555,8 @@
  
      protected void func_72979_l()
      {
@@ -794,7 +796,7 @@
          boolean flag = this.func_72896_J();
          super.func_72979_l();
  
-@@ -1200,6 +1582,8 @@
+@@ -1200,6 +1584,8 @@
              this.field_73061_a.func_184103_al().func_148540_a(new SPacketChangeGameState(7, this.field_73004_o));
              this.field_73061_a.func_184103_al().func_148540_a(new SPacketChangeGameState(8, this.field_73017_q));
          }
@@ -803,7 +805,7 @@
      }
  
      @Nullable
-@@ -1299,4 +1683,19 @@
+@@ -1299,4 +1685,19 @@
              {
              }
          }


### PR DESCRIPTION
# Feature Modifications

1. More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
2. Fixed a bug causing crashes when `/log` is executed while an invalid null option subscribes players.
3. Calculate the actual TPS when a single tick runs for more than 20 ms (by `1000/avg(max(50,millis))`). Thus, `TPS` and `MSPT` imply the different information.
4. More options of MSPT | TPS logger:
    1. `average`: (Default) The average within 100 gt, similar to the old logger.
    2. `sample`: The average within `HUDUpdateInterval`.
    3. `peak`: `MSPT` for the worst tick time, `TPS` for the average, both within `HUDUpdateInterval`.
5. Modifications of carpet profiling terms:
    1. Add `carpet`: The carpet server ticking.
    2. Add `<dim>`: Total tick time of each dimension.
    3. Add `<dim>.tile_ticks`, `<dim>.chunk_ticks`, `<dim>.block_events`, `<dim>.rest`.
    4. Remove `<dim>.blocks`.