### PR TITLE
More powerful `updateSuppressionCrashFix`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,12 +10,12 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 4. Add a spawning rate calculator.
 5. Define and throw `ChunkNotGeneratedException`.
 6. Make command `/perimeterinfo` check multiple entities.
-7. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
 
 # Feature Modifications
 
 1. Fixed the bug that `updateSuppressionCrashFix` still fails under instant tile ticks ([issue#25](https://github.com/Rainyaphthyl/carpet12RNY/issues/25#issue-1759841478)).
 2. Rule `updateSuppressionCrashFix` is enabled to deal with `ClassCastException` (the magic box).
+3. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
 
 # Code Details
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,14 +10,15 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 4. Add a spawning rate calculator.
 5. Define and throw `ChunkNotGeneratedException`.
 6. Make command `/perimeterinfo` check multiple entities.
-7. Make rule `updateSuppressionCrashFix` fix the crashes caused by ClassCastException.
-8. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
+7. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
 
 # Feature Modifications
 
-1. Fix the bug that `updateSuppressionCrashFix` still fails under instant tile ticks ([issue#25](https://github.com/Rainyaphthyl/carpet12RNY/issues/25#issue-1759841478)).
+1. Fixed the bug that `updateSuppressionCrashFix` still fails under instant tile ticks ([issue#25](https://github.com/Rainyaphthyl/carpet12RNY/issues/25#issue-1759841478)).
+2. Rule `updateSuppressionCrashFix` is enabled to deal with `ClassCastException` (the magic box).
 
 # Code Details
 
 1. Remove method `validateInstantScheduling` and `validateInstantFallingFlag` in `CarpetSettings`.
 2. Rewrite the usages of `instantScheduling` and `instantFallingFlag`.
+3. Add more constructors of `ThrowableSuppression`, setting the init causes.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,4 +20,5 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 
 # Code Details
 
-1. *None*
+1. Remove method `validateInstantScheduling` and `validateInstantFallingFlag` in `CarpetSettings`.
+2. Rewrite the usages of `instantScheduling` and `instantFallingFlag`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,12 +13,12 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 
 # Feature Modifications
 
-1. Fixed the bug that `updateSuppressionCrashFix` still fails under instant tile ticks ([issue#25](https://github.com/Rainyaphthyl/carpet12RNY/issues/25#issue-1759841478)).
+1. Fixed the bug that `updateSuppressionCrashFix` fails at the moment `instantScheduling` turns on. ([issue#25](https://github.com/Rainyaphthyl/carpet12RNY/issues/25#issue-1759841478))
 2. Rule `updateSuppressionCrashFix` is enabled to deal with `ClassCastException` (the magic box).
-3. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
+3. Display the causes, game phases, positions, and more details of potential server crashes under `updateSuppressionCrashFix`.
 
 # Code Details
 
 1. Remove method `validateInstantScheduling` and `validateInstantFallingFlag` in `CarpetSettings`.
 2. Rewrite the usages of `instantScheduling` and `instantFallingFlag`.
-3. Add more constructors of `ThrowableSuppression`, setting the init causes.
+3. Add more methods of `ThrowableSuppression`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,29 +4,20 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 
 # TO-DO List
 
-- Bump to release versions after merging pathfinding-logger?
-- Add another mode of mob-cap logger.
-- Make command `/spawn list` smarter: parsing the block position above the floor.
-- Add a spawning rate calculator.
-- Define and throw `ChunkNotGeneratedException`.
-- Make command `/perimeterinfo` check multiple entities.
+1. Bump to release versions after merging pathfinding-logger?
+2. Add another mode of mob-cap logger.
+3. Make command `/spawn list` smarter: parsing the block position above the floor.
+4. Add a spawning rate calculator.
+5. Define and throw `ChunkNotGeneratedException`.
+6. Make command `/perimeterinfo` check multiple entities.
+7. Make rule `updateSuppressionCrashFix` fix the crashes caused by ClassCastException.
+8. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
+9. Fix the bug that `updateSuppressionCrashFix` still fails under instant tile ticks.
 
 # Feature Modifications
 
-1. Improved help info of command `/spawn`.
-2. More options added to command "profile": `/profile (health|entities) <ticks>`. Command `/tick` can be disabled in vanilla survival, totally replaced by `/profile` without `/tick (rate|warp)`.
-3. Fixed a bug causing crashes when `/log` is executed while an invalid null option subscribes players.
-4. Calculate the actual TPS when a single tick runs for more than 20 ms (by `1000/avg(max(50,millis))`). Thus, `TPS` and `MSPT` imply the different information.
-5. More options of MSPT | TPS logger:
-    1. `average`: (Default) The average within 100 gt, similar to the old logger.
-    2. `sample`: The average within `HUDUpdateInterval`.
-    3. `peak`: `MSPT` for the worst tick time, `TPS` for the average, both within `HUDUpdateInterval`.
-6. Modifications of carpet profiling terms:
-    1. Add `carpet`: The carpet server ticking.
-    2. Add `<dim>`: Total tick time of each dimension.
-    3. Add `<dim>.tile_ticks`, `<dim>.chunk_ticks`, `<dim>.block_events`, `<dim>.rest`.
-    4. Remove `<dim>.blocks`.
+1. *None*
 
 # Code Details
 
-- *None*
+1. *None*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,11 +12,10 @@ Carpet 1.12 with [RNY](https://github.com/Rainyaphthyl)'s Addition
 6. Make command `/perimeterinfo` check multiple entities.
 7. Make rule `updateSuppressionCrashFix` fix the crashes caused by ClassCastException.
 8. Display the causes of potential server crashes under `updateSuppressionCrashFix`.
-9. Fix the bug that `updateSuppressionCrashFix` still fails under instant tile ticks.
 
 # Feature Modifications
 
-1. *None*
+1. Fix the bug that `updateSuppressionCrashFix` still fails under instant tile ticks ([issue#25](https://github.com/Rainyaphthyl/carpet12RNY/issues/25#issue-1759841478)).
 
 # Code Details
 

--- a/carpetmodSrc/carpet/CarpetSettings.java
+++ b/carpetmodSrc/carpet/CarpetSettings.java
@@ -182,34 +182,11 @@ public class CarpetSettings
     @Rule(desc = "Makes update carpet public for all users.", category = CREATIVE)
     public static boolean updateCarpetAll;
 
-    @Rule(desc = "Sets the instant falling flag to true. The boolean used in world population that can be exploited turning true making falling blocks fall instantly.", category = CREATIVE, validator = "validateInstantFallingFlag")
+    @Rule(desc = "Sets the instant falling flag to true. The boolean used in world population that can be exploited turning true making falling blocks fall instantly.", category = CREATIVE)
     public static boolean instantFallingFlag = false;
 
-    private static boolean validateInstantFallingFlag(boolean value) {
-        if (value) {
-            BlockFalling.fallInstantly = true;
-        }else {
-            BlockFalling.fallInstantly = false;
-        }
-        return true;
-    }
-
-    @Rule(desc = "Sets the instant scheduled updates instantly to true. The boolean used in world population that can be exploited turning true making all repeaters, comperators, observers and similar components update instantly.", category = CREATIVE, validator = "validateInstantScheduling")
+    @Rule(desc = "Sets the instant scheduled updates instantly to true. The boolean used in world population that can be exploited turning true making all repeaters, comparators, observers and similar components update instantly.", category = CREATIVE)
     public static boolean instantScheduling = false;
-    private static boolean validateInstantScheduling(boolean value) {
-        if (value) {
-            for (int dim = 0; dim < 3; dim++) {
-                WorldServer world = CarpetServer.minecraft_server.worlds[dim];
-                world.scheduledUpdatesAreImmediate = true;
-            }
-        }else {
-            for (int dim = 0; dim < 3; dim++) {
-                WorldServer world = CarpetServer.minecraft_server.worlds[dim];
-                world.scheduledUpdatesAreImmediate = false;
-            }
-        }
-        return true;
-    }
 
     @Rule(desc = "Beacons send out async block updates when powered", category = CREATIVE)
     public static boolean asyncBeaconUpdates = false;

--- a/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
+++ b/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
@@ -1,6 +1,6 @@
 package carpet.helpers;
 
-public class ThrowableSuppression extends RuntimeException{
+public class ThrowableSuppression extends RuntimeException {
     public ThrowableSuppression(String message) {
         super(message);
     }
@@ -8,7 +8,7 @@ public class ThrowableSuppression extends RuntimeException{
     /**
      * {@code message = "Update Suppression"} by default
      */
-    public ThrowableSuppression(){
+    public ThrowableSuppression() {
         this("Update Suppression");
     }
 }

--- a/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
+++ b/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
@@ -1,19 +1,69 @@
 package carpet.helpers;
 
+import carpet.utils.Messenger;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+
 public class ThrowableSuppression extends RuntimeException {
-    public ThrowableSuppression(String message) {
+    private BlockPos blockPos = null;
+
+    private ThrowableSuppression(String message) {
         super(message);
     }
 
     /**
      * {@code message = "Update Suppression"} by default
      */
-    public ThrowableSuppression() {
+    private ThrowableSuppression() {
         this("Update Suppression");
     }
 
-    public ThrowableSuppression(Throwable cause) {
+    private ThrowableSuppression(Throwable cause) {
         this();
         initCause(cause);
+    }
+
+    public ThrowableSuppression(Throwable cause, BlockPos blockPos) {
+        this(cause);
+        this.blockPos = blockPos == null ? null : blockPos.toImmutable();
+    }
+
+    public static void printServerWarning(Throwable throwable, MinecraftServer server, String phase) {
+        if (throwable instanceof ThrowableSuppression) {
+            try {
+                ((ThrowableSuppression) throwable).printServerWarning(server, phase);
+            } catch (Throwable e) {
+                Messenger.print_server_message(server, "A server crash in " + phase + " is failed to be reported.");
+            }
+        } else {
+            Messenger.print_server_message(server, "You just caused a server crash in " + phase + ".");
+        }
+    }
+
+    private void printServerWarning(MinecraftServer server, String phase) {
+        Throwable cause = getCause();
+        ITextComponent position = blockPos == null ? Messenger.c("d unknown position")
+                : Messenger.tpa("d", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+        ITextComponent reason;
+        if (cause == null) {
+            reason = Messenger.c("r unknown reasons");
+        } else {
+            String fullName = cause.getClass().getTypeName();
+            int iPostDot = fullName.lastIndexOf('.') + 1;
+            String packName = iPostDot <= 0 ? "" : fullName.substring(0, iPostDot);
+            String clzName = fullName.substring(iPostDot);
+            String message = cause.getMessage();
+            if (message == null) {
+                message = getMessage();
+            }
+            reason = Messenger.c("n  - ", "r " + packName, "c " + clzName);
+            if (message != null) {
+                reason.appendSibling(Messenger.c("n \n - ", "r " + message));
+            }
+        }
+        ITextComponent report = Messenger.c("r Server crashed in ", "m " + phase,
+                "r  at ", position, "n \n", reason);
+        Messenger.print_server_message(server, report);
     }
 }

--- a/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
+++ b/carpetmodSrc/carpet/helpers/ThrowableSuppression.java
@@ -11,4 +11,9 @@ public class ThrowableSuppression extends RuntimeException {
     public ThrowableSuppression() {
         this("Update Suppression");
     }
+
+    public ThrowableSuppression(Throwable cause) {
+        this();
+        initCause(cause);
+    }
 }

--- a/patches/net/minecraft/block/BlockDragonEgg.java.patch
+++ b/patches/net/minecraft/block/BlockDragonEgg.java.patch
@@ -22,18 +22,20 @@
  public class BlockDragonEgg extends Block
  {
      protected static final AxisAlignedBB field_185660_a = new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 1.0D, 0.9375D);
-@@ -50,8 +58,8 @@
+@@ -50,8 +58,10 @@
          {
              int i = 32;
  
 -            if (!BlockFalling.field_149832_M && p_180683_1_.func_175707_a(p_180683_2_.func_177982_a(-32, -32, -32), p_180683_2_.func_177982_a(32, 32, 32)))
 -            {
-+            if ((!BlockFalling.field_149832_M && p_180683_1_.func_175707_a(p_180683_2_.func_177982_a(-32, -32, -32), p_180683_2_.func_177982_a(32, 32, 32)))
++            // carpet12RNY - rewrite instantFallingFlag
++            if ((!(BlockFalling.field_149832_M || CarpetSettings.instantFallingFlag) && p_180683_1_.func_175707_a(p_180683_2_.func_177982_a(-32, -32, -32), p_180683_2_.func_177982_a(32, 32, 32)))
++            //if ((!BlockFalling.fallInstantly && worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32)))
 +                    && (!CarpetSettings.commandLazyChunkBehavior || LazyChunkBehaviorHelper.shouldUpdate(p_180683_1_, p_180683_2_))) {
                  p_180683_1_.func_72838_d(new EntityFallingBlock(p_180683_1_, (double)((float)p_180683_2_.func_177958_n() + 0.5F), (double)p_180683_2_.func_177956_o(), (double)((float)p_180683_2_.func_177952_p() + 0.5F), this.func_176223_P()));
              }
              else
-@@ -74,10 +82,48 @@
+@@ -74,10 +84,48 @@
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, EnumFacing p_180639_6_, float p_180639_7_, float p_180639_8_, float p_180639_9_)
      {

--- a/patches/net/minecraft/block/BlockFalling.java.patch
+++ b/patches/net/minecraft/block/BlockFalling.java.patch
@@ -10,12 +10,14 @@
  import net.minecraft.block.material.Material;
  import net.minecraft.block.state.IBlockState;
  import net.minecraft.creativetab.CreativeTabs;
-@@ -48,7 +51,8 @@
+@@ -48,7 +51,10 @@
          {
              int i = 32;
  
 -            if (!field_149832_M && p_176503_1_.func_175707_a(p_176503_2_.func_177982_a(-32, -32, -32), p_176503_2_.func_177982_a(32, 32, 32)))
-+            if ((!field_149832_M && p_176503_1_.func_175707_a(p_176503_2_.func_177982_a(-32, -32, -32), p_176503_2_.func_177982_a(32, 32, 32)) )
++            // carpet12RNY - rewrite instantFallingFlag
++            if ((!(field_149832_M || CarpetSettings.instantFallingFlag) && p_176503_1_.func_175707_a(p_176503_2_.func_177982_a(-32, -32, -32), p_176503_2_.func_177982_a(32, 32, 32)))
++            //if ((!fallInstantly && worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32)) )
 +                    && (!CarpetSettings.commandLazyChunkBehavior || LazyChunkBehaviorHelper.shouldUpdate(p_176503_1_, p_176503_2_)))
              {
                  if (!p_176503_1_.field_72995_K)

--- a/patches/net/minecraft/block/BlockFrostedIce.java.patch
+++ b/patches/net/minecraft/block/BlockFrostedIce.java.patch
@@ -20,7 +20,7 @@
 +                try {
 +                    p_180650_1_.func_175684_a(p_180650_2_, this, MathHelper.func_76136_a(p_180650_4_, 20, 40));
 +                } catch (StackOverflowError suppression) {
-+                    throw new ThrowableSuppression(suppression);
++                    throw new ThrowableSuppression(suppression, p_180650_2_);
 +                }
 +            } else
 +            // CM end

--- a/patches/net/minecraft/block/BlockFrostedIce.java.patch
+++ b/patches/net/minecraft/block/BlockFrostedIce.java.patch
@@ -20,7 +20,7 @@
 +                try {
 +                    p_180650_1_.func_175684_a(p_180650_2_, this, MathHelper.func_76136_a(p_180650_4_, 20, 40));
 +                } catch (StackOverflowError suppression) {
-+                    throw new ThrowableSuppression();
++                    throw new ThrowableSuppression(suppression);
 +                }
 +            } else
 +            // CM end

--- a/patches/net/minecraft/block/BlockShulkerBox.java.patch
+++ b/patches/net/minecraft/block/BlockShulkerBox.java.patch
@@ -37,7 +37,7 @@
 +            return Container.func_94526_b((IInventory) p_180641_2_.func_175625_s(p_180641_3_));
 +        } catch (ClassCastException exception) {
 +            if (CarpetSettings.updateSuppressionCrashFix) {
-+                throw new ThrowableSuppression(exception);
++                throw new ThrowableSuppression(exception, p_180641_3_);
 +            } else {
 +                throw exception;
 +            }

--- a/patches/net/minecraft/block/BlockShulkerBox.java.patch
+++ b/patches/net/minecraft/block/BlockShulkerBox.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockShulkerBox.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockShulkerBox.java
-@@ -32,6 +32,8 @@
+@@ -1,5 +1,7 @@
+ package net.minecraft.block;
+ 
++import carpet.helpers.ThrowableSuppression;
++import carpet.utils.Messenger;
+ import net.minecraft.block.material.EnumPushReaction;
+ import net.minecraft.block.material.MapColor;
+ import net.minecraft.block.material.Material;
+@@ -32,6 +34,8 @@
  import net.minecraft.world.IBlockAccess;
  import net.minecraft.world.World;
  
@@ -9,7 +17,7 @@
  public class BlockShulkerBox extends BlockContainer
  {
      public static final PropertyEnum<EnumFacing> field_190957_a = PropertyDirection.func_177714_a("facing");
-@@ -176,7 +178,7 @@
+@@ -176,7 +180,7 @@
                  NBTTagCompound nbttagcompound = new NBTTagCompound();
                  NBTTagCompound nbttagcompound1 = new NBTTagCompound();
                  nbttagcompound.func_74782_a("BlockEntityTag", ((TileEntityShulkerBox)tileentity).func_190580_f(nbttagcompound1));
@@ -18,3 +26,22 @@
  
                  if (tileentityshulkerbox.func_145818_k_())
                  {
+@@ -211,7 +215,17 @@
+ 
+     public int func_180641_l(IBlockState p_180641_1_, World p_180641_2_, BlockPos p_180641_3_)
+     {
+-        return Container.func_94526_b((IInventory)p_180641_2_.func_175625_s(p_180641_3_));
++        //return Container.calcRedstoneFromInventory((IInventory) worldIn.getTileEntity(pos));
++        // carpet12RNY - updateSuppressionCrashFix - CCE
++        try {
++            return Container.func_94526_b((IInventory) p_180641_2_.func_175625_s(p_180641_3_));
++        } catch (ClassCastException exception) {
++            if (CarpetSettings.updateSuppressionCrashFix) {
++                throw new ThrowableSuppression(exception);
++            } else {
++                throw exception;
++            }
++        }
+     }
+ 
+     public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)

--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -507,8 +507,8 @@
 +                            this.func_191955_a(iblockstate);
 +                        } catch (ThrowableSuppression suppression) {
 +                            throw suppression;
-+                        } catch (StackOverflowError suppression) {
-+                            throw new ThrowableSuppression(suppression);
++                        } catch (StackOverflowError error) {
++                            throw new ThrowableSuppression(error, posIter);
 +                        } catch (Throwable throwable) {
 +                            CrashReport crashreport = CrashReport.func_85055_a(throwable, "Colliding entity with block");
 +                            CrashReportCategory crashreportcategory = crashreport.func_85058_a("Block being collided with");

--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -384,7 +384,7 @@
          return EnumFacing.func_176731_b(MathHelper.func_76128_c((double)(this.field_70177_z * 4.0F / 360.0F) + 0.5D) & 3);
      }
  
-@@ -2886,4 +3029,137 @@
+@@ -2886,4 +3029,139 @@
      {
          return 1;
      }
@@ -505,7 +505,9 @@
 +                        try {
 +                            iblockstate.func_177230_c().func_180634_a(this.field_70170_p, posIter, iblockstate, this);
 +                            this.func_191955_a(iblockstate);
-+                        } catch (StackOverflowError | ThrowableSuppression suppression) {
++                        } catch (ThrowableSuppression suppression) {
++                            throw suppression;
++                        } catch (StackOverflowError suppression) {
 +                            throw new ThrowableSuppression();
 +                        } catch (Throwable throwable) {
 +                            CrashReport crashreport = CrashReport.func_85055_a(throwable, "Colliding entity with block");

--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -508,7 +508,7 @@
 +                        } catch (ThrowableSuppression suppression) {
 +                            throw suppression;
 +                        } catch (StackOverflowError suppression) {
-+                            throw new ThrowableSuppression();
++                            throw new ThrowableSuppression(suppression);
 +                        } catch (Throwable throwable) {
 +                            CrashReport crashreport = CrashReport.func_85055_a(throwable, "Colliding entity with block");
 +                            CrashReportCategory crashreportcategory = crashreport.func_85058_a("Block being collided with");

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -304,21 +304,22 @@
  
                  if (this.field_71315_w % 20 == 0)
                  {
-@@ -686,41 +795,67 @@
+@@ -686,41 +795,69 @@
                  {
                      worldserver.func_72835_b();
                  }
 +                catch (ThrowableSuppression e)
 +                {
-+                    Messenger.print_server_message(this, "You just caused a server crash in world tick.");
++                    ThrowableSuppression.printServerWarning(e, this, "world tick");
 +                }
                  catch (Throwable throwable1)
                  {
                      CrashReport crashreport = CrashReport.func_85055_a(throwable1, "Exception ticking world");
                      worldserver.func_72914_a(crashreport);
 -                    throw new ReportedException(crashreport);
-+                    if (CarpetSettings.updateSuppressionCrashFix && crashreport.func_71505_b() instanceof ThrowableSuppression) {
-+                        Messenger.print_server_message(this, "You just caused a server crash in world tick.");
++                    Throwable cause = crashreport.func_71505_b();
++                    if (CarpetSettings.updateSuppressionCrashFix && cause instanceof ThrowableSuppression) {
++                        ThrowableSuppression.printServerWarning(cause, this, "world tick");
 +                    } else {
 +                        throw new ReportedException(crashreport);
 +                    }
@@ -332,15 +333,16 @@
                  }
 +                catch (ThrowableSuppression e)
 +                {
-+                    Messenger.print_server_message(this, "You just caused a server crash in update entities.");
++                    ThrowableSuppression.printServerWarning(e, this, "update entities");
 +                }
                  catch (Throwable throwable)
                  {
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable, "Exception ticking world entities");
                      worldserver.func_72914_a(crashreport1);
 -                    throw new ReportedException(crashreport1);
-+                    if (CarpetSettings.updateSuppressionCrashFix && crashreport1.func_71505_b() instanceof ThrowableSuppression) {
-+                        Messenger.print_server_message(this, "You just caused a server crash in update entities.");
++                    Throwable cause = crashreport1.func_71505_b();
++                    if (CarpetSettings.updateSuppressionCrashFix && cause instanceof ThrowableSuppression) {
++                        ThrowableSuppression.printServerWarning(cause, this, "update entities");
 +                    } else {
 +                        throw new ReportedException(crashreport1);
 +                    }
@@ -374,7 +376,7 @@
  
          for (int k = 0; k < this.field_71322_p.size(); ++k)
          {
-@@ -728,6 +863,9 @@
+@@ -728,6 +865,9 @@
          }
  
          this.field_71304_b.func_76319_b();
@@ -384,7 +386,7 @@
      }
  
      public boolean func_71255_r()
-@@ -939,7 +1077,7 @@
+@@ -939,7 +1079,7 @@
  
      public String getServerModName()
      {
@@ -393,7 +395,7 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -1512,6 +1650,7 @@
+@@ -1512,6 +1652,7 @@
      {
          if (this.func_152345_ab())
          {
@@ -401,7 +403,7 @@
              this.func_184103_al().func_72389_g();
              this.field_71305_c[0].func_184146_ak().func_186522_a();
              this.func_191949_aK().func_192779_a();
-@@ -1523,4 +1662,9 @@
+@@ -1523,4 +1664,9 @@
              this.func_152344_a(this::func_193031_aM);
          }
      }

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -317,10 +317,10 @@
                      CrashReport crashreport = CrashReport.func_85055_a(throwable1, "Exception ticking world");
                      worldserver.func_72914_a(crashreport);
 -                    throw new ReportedException(crashreport);
-+                    if(!CarpetSettings.updateSuppressionCrashFix || !(crashreport.func_71505_b() instanceof ThrowableSuppression) ) {
-+                        throw new ReportedException(crashreport);
-+                    } else {
++                    if (CarpetSettings.updateSuppressionCrashFix && crashreport.func_71505_b() instanceof ThrowableSuppression) {
 +                        Messenger.print_server_message(this, "You just caused a server crash in world tick.");
++                    } else {
++                        throw new ReportedException(crashreport);
 +                    }
                  }
  
@@ -339,10 +339,10 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable, "Exception ticking world entities");
                      worldserver.func_72914_a(crashreport1);
 -                    throw new ReportedException(crashreport1);
-+                    if(!CarpetSettings.updateSuppressionCrashFix || !(crashreport1.func_71505_b() instanceof ThrowableSuppression) ) {
-+                        throw new ReportedException(crashreport1);
-+                    } else {
++                    if (CarpetSettings.updateSuppressionCrashFix && crashreport1.func_71505_b() instanceof ThrowableSuppression) {
 +                        Messenger.print_server_message(this, "You just caused a server crash in update entities.");
++                    } else {
++                        throw new ReportedException(crashreport1);
 +                    }
                  }
  

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -688,7 +688,7 @@
 +            }
 +            catch (StackOverflowError e)
 +            {
-+                throw new ThrowableSuppression(e);
++                throw new ThrowableSuppression(e, pos);
 +            }
 +            catch (Throwable throwable)
 +            {
@@ -739,7 +739,7 @@
 +                }
 +                catch (StackOverflowError e)
 +                {
-+                    throw new ThrowableSuppression(e);
++                    throw new ThrowableSuppression(e, pos);
 +                }
 +                catch (Throwable throwable)
 +                {

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -649,7 +649,7 @@
      }
  
      public DifficultyInstance func_175649_E(BlockPos p_175649_1_)
-@@ -3361,4 +3604,126 @@
+@@ -3361,4 +3604,130 @@
      {
          return null;
      }
@@ -728,6 +728,10 @@
 +                {
 +                    WorldHelper.onObserverUpdate(this, pos); // RSMM
 +                    ((BlockObserver)iblockstate.func_177230_c()).func_190962_b(iblockstate, this, pos, changedBlock, changedBlockPos);
++                }
++                catch (ThrowableSuppression suppression)
++                {
++                    throw suppression;
 +                }
 +                catch (StackOverflowError e)
 +                {

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -649,7 +649,7 @@
      }
  
      public DifficultyInstance func_175649_E(BlockPos p_175649_1_)
-@@ -3361,4 +3604,130 @@
+@@ -3361,4 +3604,134 @@
      {
          return null;
      }
@@ -682,9 +682,13 @@
 +                WorldHelper.onBlockUpdate(this, pos, iblockstate); // RSMM
 +                iblockstate.func_189546_a(this, pos, blockIn, fromPos);
 +            }
-+            catch (ThrowableSuppression | StackOverflowError e)
++            catch (ThrowableSuppression suppression)
 +            {
-+                throw new ThrowableSuppression("Update Suppression");
++                throw suppression;
++            }
++            catch (StackOverflowError e)
++            {
++                throw new ThrowableSuppression(e);
 +            }
 +            catch (Throwable throwable)
 +            {
@@ -735,7 +739,7 @@
 +                }
 +                catch (StackOverflowError e)
 +                {
-+                    throw new ThrowableSuppression("Update Suppression");
++                    throw new ThrowableSuppression(e);
 +                }
 +                catch (Throwable throwable)
 +                {

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -1,11 +1,10 @@
 --- ../src-base/minecraft/net/minecraft/world/WorldServer.java
 +++ ../src-work/minecraft/net/minecraft/world/WorldServer.java
-@@ -1,5 +1,12 @@
+@@ -1,5 +1,11 @@
  package net.minecraft.world;
  
++import carpet.helpers.*;
 +import carpet.helpers.lifetime.LifeTimeWorldTracker;
-+import carpet.helpers.NextTickListEntryFix;
-+import carpet.helpers.ScheduledBlockEventSerializer;
 +import carpet.helpers.endermelon.EndermelonMonitor;
 +import carpet.logging.logHelpers.LightCheckReporter;
 +import carpet.logging.logHelpers.RNGMonitor;
@@ -13,7 +12,7 @@
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -14,7 +21,6 @@
+@@ -14,7 +20,6 @@
  import java.util.Set;
  import java.util.TreeSet;
  import java.util.UUID;
@@ -21,7 +20,7 @@
  import java.util.stream.Collectors;
  import javax.annotation.Nullable;
  import net.minecraft.advancements.AdvancementManager;
-@@ -60,6 +66,7 @@
+@@ -60,6 +65,7 @@
  import net.minecraft.util.math.ChunkPos;
  import net.minecraft.util.math.MathHelper;
  import net.minecraft.util.math.Vec3d;
@@ -29,7 +28,7 @@
  import net.minecraft.village.VillageCollection;
  import net.minecraft.village.VillageSiege;
  import net.minecraft.world.biome.Biome;
-@@ -77,17 +84,32 @@
+@@ -77,17 +83,29 @@
  import net.minecraft.world.storage.WorldInfo;
  import net.minecraft.world.storage.WorldSavedDataCallableSave;
  import net.minecraft.world.storage.loot.LootTableManager;
@@ -43,9 +42,6 @@
  
 +import carpet.CarpetSettings;
 +import carpet.CarpetServer;
-+import carpet.helpers.LagSpikeHelper;
-+import carpet.helpers.RandomTickOptimization;
-+import carpet.helpers.TickSpeed;
 +import carpet.logging.LoggerRegistry;
 +import carpet.utils.CarpetProfiler;
 +import carpet.utils.Messenger;
@@ -65,7 +61,7 @@
      private final Map<UUID, Entity> field_175741_N = Maps.<UUID, Entity>newHashMap();
      public boolean field_73058_d;
      private boolean field_73068_P;
-@@ -99,6 +121,22 @@
+@@ -99,6 +117,22 @@
      private int field_147489_T;
      private final List<NextTickListEntry> field_94579_S = Lists.<NextTickListEntry>newArrayList();
  
@@ -88,7 +84,7 @@
      public WorldServer(MinecraftServer p_i45921_1_, ISaveHandler p_i45921_2_, WorldInfo p_i45921_3_, int p_i45921_4_, Profiler p_i45921_5_)
      {
          super(p_i45921_2_, p_i45921_3_, DimensionType.func_186069_a(p_i45921_4_).func_186070_d(), p_i45921_5_, false);
-@@ -111,8 +149,21 @@
+@@ -111,8 +145,21 @@
          this.func_72966_v();
          this.func_72947_a();
          this.func_175723_af().func_177725_a(p_i45921_1_.func_175580_aG());
@@ -110,7 +106,7 @@
      public World func_175643_b()
      {
          this.field_72988_C = new MapStorage(this.field_73019_z);
-@@ -159,11 +210,30 @@
+@@ -159,11 +206,30 @@
              this.func_175723_af().func_177750_a(this.field_72986_A.func_176137_E());
          }
  
@@ -141,7 +137,7 @@
          super.func_72835_b();
  
          if (this.func_72912_H().func_76093_s() && this.func_175659_aa() != EnumDifficulty.HARD)
-@@ -184,15 +254,31 @@
+@@ -184,15 +250,31 @@
              this.func_73053_d();
          }
  
@@ -173,7 +169,7 @@
          int j = this.func_72967_a(1.0F);
  
          if (j != this.func_175657_ab())
-@@ -200,26 +286,103 @@
+@@ -200,26 +282,103 @@
              this.func_175692_b(j);
          }
  
@@ -279,7 +275,7 @@
      }
  
      @Nullable
-@@ -255,13 +418,22 @@
+@@ -255,13 +414,22 @@
                      ++j;
                  }
              }
@@ -304,7 +300,7 @@
          this.field_73068_P = false;
  
          for (EntityPlayer entityplayer : this.field_73010_i.stream().filter(EntityPlayer::func_70608_bn).collect(Collectors.toList()))
-@@ -273,6 +445,8 @@
+@@ -273,6 +441,8 @@
          {
              this.func_73051_P();
          }
@@ -313,7 +309,7 @@
      }
  
      private void func_73051_P()
-@@ -287,6 +461,28 @@
+@@ -287,6 +457,28 @@
      {
          if (this.field_73068_P && !this.field_72995_K)
          {
@@ -342,7 +338,7 @@
              for (EntityPlayer entityplayer : this.field_73010_i)
              {
                  if (!entityplayer.func_175149_v() && !entityplayer.func_71026_bH())
-@@ -303,7 +499,7 @@
+@@ -303,7 +495,7 @@
          }
      }
  
@@ -351,7 +347,7 @@
      {
          return this.func_72863_F().func_73149_a(p_175680_1_, p_175680_2_);
      }
-@@ -311,15 +507,84 @@
+@@ -311,15 +503,84 @@
      protected void func_184162_i()
      {
          this.field_72984_F.func_76320_a("playerCheckLight");
@@ -438,7 +434,7 @@
          }
  
          this.field_72984_F.func_76319_b();
-@@ -344,7 +609,13 @@
+@@ -344,7 +605,13 @@
              boolean flag = this.func_72896_J();
              boolean flag1 = this.func_72911_I();
              this.field_72984_F.func_76320_a("pollingChunks");
@@ -452,7 +448,7 @@
              for (Iterator<Chunk> iterator = this.field_73063_M.func_187300_b(); iterator.hasNext(); this.field_72984_F.func_76319_b())
              {
                  this.field_72984_F.func_76320_a("getChunk");
-@@ -354,10 +625,18 @@
+@@ -354,10 +621,18 @@
                  this.field_72984_F.func_76318_c("checkNextLight");
                  chunk.func_76594_o();
                  this.field_72984_F.func_76318_c("tickChunk");
@@ -472,7 +468,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int l = this.field_73005_l >> 2;
-@@ -384,8 +663,9 @@
+@@ -384,8 +659,9 @@
                  }
  
                  this.field_72984_F.func_76318_c("iceandsnow");
@@ -483,7 +479,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int j2 = this.field_73005_l >> 2;
-@@ -409,6 +689,7 @@
+@@ -409,6 +685,7 @@
                  }
  
                  this.field_72984_F.func_76318_c("tickBlocks");
@@ -491,7 +487,7 @@
  
                  if (i > 0)
                  {
-@@ -429,7 +710,15 @@
+@@ -429,7 +706,15 @@
  
                                  if (block.func_149653_t())
                                  {
@@ -508,7 +504,7 @@
                                  }
  
                                  this.field_72984_F.func_76319_b();
-@@ -437,13 +726,15 @@
+@@ -437,13 +722,15 @@
                          }
                      }
                  }
@@ -525,7 +521,7 @@
      {
          BlockPos blockpos = this.func_175725_q(p_175736_1_);
          AxisAlignedBB axisalignedbb = (new AxisAlignedBB(blockpos, new BlockPos(blockpos.func_177958_n(), this.func_72800_K(), blockpos.func_177952_p()))).func_186662_g(3.0D);
-@@ -472,13 +763,25 @@
+@@ -472,13 +759,25 @@
  
      public boolean func_175691_a(BlockPos p_175691_1_, Block p_175691_2_)
      {
@@ -553,7 +549,7 @@
          return this.field_73064_N.contains(nextticklistentry);
      }
  
-@@ -491,7 +794,9 @@
+@@ -491,7 +790,9 @@
      {
          Material material = p_175654_2_.func_176223_P().func_185904_a();
  
@@ -564,7 +560,7 @@
          {
              if (p_175654_2_.func_149698_L())
              {
-@@ -501,17 +806,29 @@
+@@ -501,17 +802,29 @@
  
                      if (iblockstate.func_185904_a() != Material.field_151579_a && iblockstate.func_177230_c() == p_175654_2_)
                      {
@@ -596,7 +592,7 @@
  
          if (this.func_175667_e(p_175654_1_))
          {
-@@ -531,7 +848,13 @@
+@@ -531,7 +844,13 @@
  
      public void func_180497_b(BlockPos p_180497_1_, Block p_180497_2_, int p_180497_3_, int p_180497_4_)
      {
@@ -611,7 +607,7 @@
          nextticklistentry.func_82753_a(p_180497_4_);
          Material material = p_180497_2_.func_176223_P().func_185904_a();
  
-@@ -549,7 +872,8 @@
+@@ -549,7 +868,8 @@
  
      public void func_72939_s()
      {
@@ -621,7 +617,7 @@
          {
              if (this.field_80004_Q++ >= 300)
              {
-@@ -567,6 +891,8 @@
+@@ -567,6 +887,8 @@
  
      protected void func_184147_l()
      {
@@ -630,7 +626,7 @@
          super.func_184147_l();
          this.field_72984_F.func_76318_c("players");
  
-@@ -621,6 +947,8 @@
+@@ -621,6 +943,8 @@
  
              this.field_72984_F.func_76319_b();
          }
@@ -639,7 +635,7 @@
      }
  
      public void func_82742_i()
-@@ -644,9 +972,18 @@
+@@ -644,9 +968,18 @@
              }
              else
              {
@@ -660,7 +656,7 @@
                  }
  
                  this.field_72984_F.func_76320_a("cleaning");
-@@ -677,12 +1014,15 @@
+@@ -677,16 +1010,31 @@
  
                      if (this.func_175707_a(nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0), nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0)))
                      {
@@ -675,8 +671,24 @@
 +                                WorldHelper.onScheduledTick(this, nextticklistentry1); // RSMM
                                  iblockstate.func_177230_c().func_180650_b(this, nextticklistentry1.field_180282_a, iblockstate, this.field_73012_v);
                              }
++                            // CM - start
++                            // carpet12RNY - updateSuppressionCrashFix - ITT fix
++                            catch (ThrowableSuppression suppression) {
++                                throw suppression;
++                            }
++                            // CM - end
                              catch (Throwable throwable)
-@@ -699,6 +1039,7 @@
+                             {
++                                // CM - start
++                                // carpet12RNY - updateSuppressionCrashFix - ITT fix
++                                if (CarpetSettings.updateSuppressionCrashFix && throwable instanceof StackOverflowError) {
++                                    throw new ThrowableSuppression();
++                                }
++                                // CM - end
+                                 CrashReport crashreport = CrashReport.func_85055_a(throwable, "Exception while ticking a block");
+                                 CrashReportCategory crashreportcategory = crashreport.func_85058_a("Block being ticked");
+                                 CrashReportCategory.func_175750_a(crashreportcategory, nextticklistentry1.field_180282_a, iblockstate);
+@@ -699,6 +1047,7 @@
                          this.func_175684_a(nextticklistentry1.field_180282_a, nextticklistentry1.func_151351_a(), 0);
                      }
                  }
@@ -684,7 +696,7 @@
  
                  this.field_72984_F.func_76319_b();
                  this.field_94579_S.clear();
-@@ -950,11 +1291,18 @@
+@@ -950,11 +1299,18 @@
  
              chunkproviderserver.func_186027_a(p_73044_1_);
  
@@ -704,7 +716,7 @@
                  }
              }
          }
-@@ -1033,9 +1381,15 @@
+@@ -1033,9 +1389,15 @@
                  }
                  else
                  {
@@ -720,7 +732,7 @@
                          return false;
                      }
  
-@@ -1055,6 +1409,7 @@
+@@ -1055,6 +1417,7 @@
          this.field_175729_l.func_76038_a(p_72923_1_.func_145782_y(), p_72923_1_);
          this.field_175741_N.put(p_72923_1_.func_110124_au(), p_72923_1_);
          Entity[] aentity = p_72923_1_.func_70021_al();
@@ -728,7 +740,7 @@
  
          if (aentity != null)
          {
-@@ -1117,7 +1472,10 @@
+@@ -1117,7 +1480,10 @@
  
          for (EntityPlayer entityplayer : this.field_73010_i)
          {
@@ -740,7 +752,7 @@
              {
                  ((EntityPlayerMP)entityplayer).field_71135_a.func_147359_a(new SPacketExplosion(p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, explosion.func_180343_e(), (Vec3d)explosion.func_77277_b().get(entityplayer)));
              }
-@@ -1139,10 +1497,15 @@
+@@ -1139,10 +1505,15 @@
          }
  
          this.field_147490_S[this.field_147489_T].add(blockeventdata);
@@ -756,7 +768,7 @@
          while (!this.field_147490_S[this.field_147489_T].isEmpty())
          {
              int i = this.field_147489_T;
-@@ -1150,19 +1513,40 @@
+@@ -1150,19 +1521,40 @@
  
              for (BlockEventData blockeventdata : this.field_147490_S[i])
              {
@@ -798,7 +810,7 @@
          return iblockstate.func_177230_c() == p_147485_1_.func_151337_f() ? iblockstate.func_189547_a(this, p_147485_1_.func_180328_a(), p_147485_1_.func_151339_d(), p_147485_1_.func_151338_e()) : false;
      }
  
-@@ -1173,6 +1557,8 @@
+@@ -1173,6 +1565,8 @@
  
      protected void func_72979_l()
      {
@@ -807,7 +819,7 @@
          boolean flag = this.func_72896_J();
          super.func_72979_l();
  
-@@ -1200,6 +1586,8 @@
+@@ -1200,6 +1594,8 @@
              this.field_73061_a.func_184103_al().func_148540_a(new SPacketChangeGameState(7, this.field_73004_o));
              this.field_73061_a.func_184103_al().func_148540_a(new SPacketChangeGameState(8, this.field_73017_q));
          }
@@ -816,7 +828,7 @@
      }
  
      @Nullable
-@@ -1299,4 +1687,19 @@
+@@ -1299,4 +1695,19 @@
              {
              }
          }

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -682,7 +682,7 @@
 +                                // CM - start
 +                                // carpet12RNY - updateSuppressionCrashFix - ITT fix
 +                                if (CarpetSettings.updateSuppressionCrashFix && throwable instanceof StackOverflowError) {
-+                                    throw new ThrowableSuppression(throwable);
++                                    throw new ThrowableSuppression(throwable, nextticklistentry1.field_180282_a);
 +                                }
 +                                // CM - end
                                  CrashReport crashreport = CrashReport.func_85055_a(throwable, "Exception while ticking a block");

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -682,7 +682,7 @@
 +                                // CM - start
 +                                // carpet12RNY - updateSuppressionCrashFix - ITT fix
 +                                if (CarpetSettings.updateSuppressionCrashFix && throwable instanceof StackOverflowError) {
-+                                    throw new ThrowableSuppression();
++                                    throw new ThrowableSuppression(throwable);
 +                                }
 +                                // CM - end
                                  CrashReport crashreport = CrashReport.func_85055_a(throwable, "Exception while ticking a block");

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -553,7 +553,18 @@
          return this.field_73064_N.contains(nextticklistentry);
      }
  
-@@ -501,17 +804,29 @@
+@@ -491,7 +794,9 @@
+     {
+         Material material = p_175654_2_.func_176223_P().func_185904_a();
+ 
+-        if (this.field_72999_e && material != Material.field_151579_a)
++        // carpet12RNY - rewrite instantScheduling
++        if ((this.field_72999_e || CarpetSettings.instantScheduling) && material != Material.field_151579_a)
++        //if (this.scheduledUpdatesAreImmediate && material != Material.AIR)
+         {
+             if (p_175654_2_.func_149698_L())
+             {
+@@ -501,17 +806,29 @@
  
                      if (iblockstate.func_185904_a() != Material.field_151579_a && iblockstate.func_177230_c() == p_175654_2_)
                      {
@@ -585,7 +596,7 @@
  
          if (this.func_175667_e(p_175654_1_))
          {
-@@ -531,7 +846,13 @@
+@@ -531,7 +848,13 @@
  
      public void func_180497_b(BlockPos p_180497_1_, Block p_180497_2_, int p_180497_3_, int p_180497_4_)
      {
@@ -600,7 +611,7 @@
          nextticklistentry.func_82753_a(p_180497_4_);
          Material material = p_180497_2_.func_176223_P().func_185904_a();
  
-@@ -549,7 +870,8 @@
+@@ -549,7 +872,8 @@
  
      public void func_72939_s()
      {
@@ -610,7 +621,7 @@
          {
              if (this.field_80004_Q++ >= 300)
              {
-@@ -567,6 +889,8 @@
+@@ -567,6 +891,8 @@
  
      protected void func_184147_l()
      {
@@ -619,7 +630,7 @@
          super.func_184147_l();
          this.field_72984_F.func_76318_c("players");
  
-@@ -621,6 +945,8 @@
+@@ -621,6 +947,8 @@
  
              this.field_72984_F.func_76319_b();
          }
@@ -628,7 +639,7 @@
      }
  
      public void func_82742_i()
-@@ -644,9 +970,18 @@
+@@ -644,9 +972,18 @@
              }
              else
              {
@@ -649,7 +660,7 @@
                  }
  
                  this.field_72984_F.func_76320_a("cleaning");
-@@ -677,12 +1012,15 @@
+@@ -677,12 +1014,15 @@
  
                      if (this.func_175707_a(nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0), nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0)))
                      {
@@ -665,7 +676,7 @@
                                  iblockstate.func_177230_c().func_180650_b(this, nextticklistentry1.field_180282_a, iblockstate, this.field_73012_v);
                              }
                              catch (Throwable throwable)
-@@ -699,6 +1037,7 @@
+@@ -699,6 +1039,7 @@
                          this.func_175684_a(nextticklistentry1.field_180282_a, nextticklistentry1.func_151351_a(), 0);
                      }
                  }
@@ -673,7 +684,7 @@
  
                  this.field_72984_F.func_76319_b();
                  this.field_94579_S.clear();
-@@ -950,11 +1289,18 @@
+@@ -950,11 +1291,18 @@
  
              chunkproviderserver.func_186027_a(p_73044_1_);
  
@@ -693,7 +704,7 @@
                  }
              }
          }
-@@ -1033,9 +1379,15 @@
+@@ -1033,9 +1381,15 @@
                  }
                  else
                  {
@@ -709,7 +720,7 @@
                          return false;
                      }
  
-@@ -1055,6 +1407,7 @@
+@@ -1055,6 +1409,7 @@
          this.field_175729_l.func_76038_a(p_72923_1_.func_145782_y(), p_72923_1_);
          this.field_175741_N.put(p_72923_1_.func_110124_au(), p_72923_1_);
          Entity[] aentity = p_72923_1_.func_70021_al();
@@ -717,7 +728,7 @@
  
          if (aentity != null)
          {
-@@ -1117,7 +1470,10 @@
+@@ -1117,7 +1472,10 @@
  
          for (EntityPlayer entityplayer : this.field_73010_i)
          {
@@ -729,7 +740,7 @@
              {
                  ((EntityPlayerMP)entityplayer).field_71135_a.func_147359_a(new SPacketExplosion(p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, explosion.func_180343_e(), (Vec3d)explosion.func_77277_b().get(entityplayer)));
              }
-@@ -1139,10 +1495,15 @@
+@@ -1139,10 +1497,15 @@
          }
  
          this.field_147490_S[this.field_147489_T].add(blockeventdata);
@@ -745,7 +756,7 @@
          while (!this.field_147490_S[this.field_147489_T].isEmpty())
          {
              int i = this.field_147489_T;
-@@ -1150,19 +1511,40 @@
+@@ -1150,19 +1513,40 @@
  
              for (BlockEventData blockeventdata : this.field_147490_S[i])
              {
@@ -787,7 +798,7 @@
          return iblockstate.func_177230_c() == p_147485_1_.func_151337_f() ? iblockstate.func_189547_a(this, p_147485_1_.func_180328_a(), p_147485_1_.func_151339_d(), p_147485_1_.func_151338_e()) : false;
      }
  
-@@ -1173,6 +1555,8 @@
+@@ -1173,6 +1557,8 @@
  
      protected void func_72979_l()
      {
@@ -796,7 +807,7 @@
          boolean flag = this.func_72896_J();
          super.func_72979_l();
  
-@@ -1200,6 +1584,8 @@
+@@ -1200,6 +1586,8 @@
              this.field_73061_a.func_184103_al().func_148540_a(new SPacketChangeGameState(7, this.field_73004_o));
              this.field_73061_a.func_184103_al().func_148540_a(new SPacketChangeGameState(8, this.field_73017_q));
          }
@@ -805,7 +816,7 @@
      }
  
      @Nullable
-@@ -1299,4 +1685,19 @@
+@@ -1299,4 +1687,19 @@
              {
              }
          }


### PR DESCRIPTION
# Feature Modifications

1. Fix the bug that `updateSuppressionCrashFix` fails at the moment `instantScheduling` turns on: #25
2. Rule `updateSuppressionCrashFix` is enabled to deal with `ClassCastException` (the magic box).
3. Display the causes, game phases, positions, and more details of potential server crashes under `updateSuppressionCrashFix`.

# Code Details

1. Remove method `validateInstantScheduling` and `validateInstantFallingFlag` in `CarpetSettings`.
2. Rewrite the usages of `instantScheduling` and `instantFallingFlag`.
3. Add more methods of `ThrowableSuppression`.
